### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # espoo-dev
 
+<p align="center">
+  <img src="http://ruby.ci/badges/c9e80d1d-18a0-48f0-a533-541666383998/rspec" alt="rspec"/>
+  <img src="http://ruby.ci/badges/c9e80d1d-18a0-48f0-a533-541666383998/rubocop" alt="rubocop"/>
+  <img src="http://ruby.ci/badges/c9e80d1d-18a0-48f0-a533-541666383998/simplecov" alt="rubocop"/>
+</p>
 
 # doc
 


### PR DESCRIPTION
Hey guys, 

As per @edimossilva request, I just added support for badges on ruby.ci.

This is the initial support and may change a bit in the next few days.

Feel free to close this PR if you guys want to do this by yourselves later.

The result: https://github.com/espoo-dev/espoo-dev/blob/4c7cf9574020313d262bee8f20e3af60847b8255/README.md

Let me know if you guys need some change.

Talk soon!


