### PR TITLE
Reset cache for badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 # espoo-dev
 
 <p align="center">
-  <img src="http://ruby.ci/badges/c9e80d1d-18a0-48f0-a533-541666383998/rspec" alt="rspec"/>
-  <img src="http://ruby.ci/badges/c9e80d1d-18a0-48f0-a533-541666383998/rubocop" alt="rubocop"/>
-  <img src="http://ruby.ci/badges/c9e80d1d-18a0-48f0-a533-541666383998/simplecov" alt="rubocop"/>
+  <img src="https://ruby.ci/badges/c9e80d1d-18a0-48f0-a533-541666383998/rspec?cache=false" alt="rspec"/>
+  <img src="https://ruby.ci/badges/c9e80d1d-18a0-48f0-a533-541666383998/rubocop?cache=false" alt="rubocop"/>
+  <img src="https://ruby.ci/badges/c9e80d1d-18a0-48f0-a533-541666383998/simplecov?cache=false" alt="simplecov"/>
 </p>
 
 # 🐳 Run


### PR DESCRIPTION
Hey guys, 

I fixed the badge cache, this PR flushes the cache.

If you guys like some alternative styles, just change the style params:

### Default
![rspec](https://ruby.ci/badges/c9e80d1d-18a0-48f0-a533-541666383998/rspec)
### ?style=plastic
![rspec](https://ruby.ci/badges/c9e80d1d-18a0-48f0-a533-541666383998/rspec?style=plastic)
### ?style=flat
![rspec](https://ruby.ci/badges/c9e80d1d-18a0-48f0-a533-541666383998/rspec?style=flat)
### ?style=for-the-badge
![rspec](https://ruby.ci/badges/c9e80d1d-18a0-48f0-a533-541666383998/rspec?style=for-the-badge)



