### PR TITLE
Add question policy and Rspec tests

### DIFF
--- a/backend/app/policies/question_policy.rb
+++ b/backend/app/policies/question_policy.rb
@@ -1,2 +1,11 @@
-class QuestionPolicy < ApplicationPolicy
+class QuestionPolicy < GenericPolicy
+  class Scope < Scope
+    def resolve_admin
+      if user.admin?
+        Question.all
+      else
+        Question.where(user_id: user.id)
+      end
+    end
+  end
 end

--- a/backend/app/policies/question_type_policy.rb
+++ b/backend/app/policies/question_type_policy.rb
@@ -1,9 +1,2 @@
 class QuestionTypePolicy < ApplicationPolicy
-  def index?
-    user?
-  end
-
-  def show?
-    user?
-  end
 end

--- a/backend/spec/system/question_type_crud_spec.rb
+++ b/backend/spec/system/question_type_crud_spec.rb
@@ -5,7 +5,6 @@ RSpec.describe 'question_type CRUD', type: :system do
   describe 'CRUD' do
     let!(:question_type) { create(:question_type) }
     let!(:admin_user) { create(:user) }
-    let!(:user_teacher) { create(:user_teacher) }
 
     describe 'when user is admin' do
       before do
@@ -25,31 +24,6 @@ RSpec.describe 'question_type CRUD', type: :system do
         page.accept_alert
 
         expect(page).to have_text('Question type was successfully destroyed.')
-      end
-    end
-
-    describe 'when user is not admin' do
-      before do
-        sign_in user_teacher
-      end
-
-      it 'can show question_type' do
-        visit "/admin/question_types/#{question_type.id}"
-
-        expect(page).to have_text(question_type.name)
-        expect(page).not_to have_text(question_type.id)
-      end
-
-      it 'can list question_type' do
-        visit '/admin/question_types/'
-
-        expect(page).to have_text(question_type.name)
-      end
-
-      it 'cannot delete question_type' do
-        visit '/admin/question_types'
-
-        expect(page).not_to have_text('Destroy')
       end
     end
   end


### PR DESCRIPTION
# Question Policy

## **Policy:**
**QuestionPolicy:**
- Add a scope to show all the questions when the user is admin.
- Add a scope to the policy to only show questions created by the user.

**QuestionTypePolicy:**
- Remove index and show for the user.

## **Rspec:**

**Question:**
- Rearrange the question_crud_spec.rb file to have separate tests for teacher and admin.
- Add tests for showing the questions when the user is a teacher or admin.
- Add tests for creating a question for the teacher.
- Add tests for hiding ID when logged in as a teacher.

**Question_type:**
- Remove tests for the user when not logged in as admin.

Co-authored-by: Valmir Júnior <ValmirJuniorr@users.noreply.github.com>

fix #96 