### PR TITLE
Change almost all of the hard coded paths to rails helper paths

### DIFF
--- a/backend/spec/requests/surveys_request_spec.rb
+++ b/backend/spec/requests/surveys_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'SurveysController', type: :request do
     let!(:survey_question) { survey.questions.first }
     let!(:question_type) { survey_question.question_type }
 
-    before { get api_v1_survey_path(survey.id), headers: auth_headers }
+    before { get api_v1_survey_path(survey), headers: auth_headers }
 
     it { expect(response).to have_http_status :ok }
 
@@ -57,7 +57,7 @@ RSpec.describe 'SurveysController', type: :request do
         create(:survey, name: 'test 2', user_id: user.id)
         another_user = create(:user)
         create(:survey, name: 'test 1', user_id: another_user.id)
-        get api_v1_surveys_path << "?user_id=#{another_user.id}", headers: auth_headers
+        get api_v1_surveys_path(user_id: another_user.id), headers: auth_headers
       end
 
       it { expect(response).to have_http_status :success }

--- a/backend/spec/requests/users_request_spec.rb
+++ b/backend/spec/requests/users_request_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'UsersController', type: :request do
     describe 'when has no headers' do
       before do
         create(:user)
-        get '/api/v1/users'
+        get api_v1_users_path
       end
 
       it { expect(response).to have_http_status :found }
@@ -96,7 +96,7 @@ RSpec.describe 'UsersController', type: :request do
       let!(:survey) { user_with_surveys.surveys.first }
 
       before do
-        get '/api/v1/users', headers: auth_headers
+        get api_v1_users_path, headers: auth_headers
       end
 
       it 'has user with surveys' do
@@ -129,7 +129,7 @@ RSpec.describe 'UsersController', type: :request do
         before do
           create(:user)
           create(:user_moderator)
-          get '/api/v1/users?role=teacher', headers: auth_headers
+          get api_v1_users_path(role: 'teacher'), headers: auth_headers
         end
 
         it { expect(response).to have_http_status :success }
@@ -153,7 +153,7 @@ RSpec.describe 'UsersController', type: :request do
         before do
           create(:user)
           role = create(:role, role_type: 'test')
-          get "/api/v1/users?role_id=#{role.id}", headers: auth_headers
+          get api_v1_users_path(role_id: role.id), headers: auth_headers
         end
 
         it { expect(response).to have_http_status :success }
@@ -167,7 +167,7 @@ RSpec.describe 'UsersController', type: :request do
     context 'when has no params' do
       before do
         create_list(:user, 5)
-        get '/api/v1/users', headers: auth_headers
+        get api_v1_users_path, headers: auth_headers
       end
 
       it { expect(response).to have_http_status :success }

--- a/backend/spec/system/admin_crud_spec.rb
+++ b/backend/spec/system/admin_crud_spec.rb
@@ -8,13 +8,13 @@ RSpec.describe 'Admin CRUD', type: :system do
     let!(:role) { create(:role_teacher) }
 
     it 'goes to log in page when user is not logged' do
-      visit '/admin/users/new'
-      expect(page).to have_current_path('/users/sign_in')
+      visit new_admin_user_path
+      expect(page).to have_current_path(new_user_session_path)
     end
 
     it 'creates user' do
       sign_in user
-      visit '/admin/users/new'
+      visit new_admin_user_path
 
       fill_in 'Email', with: user2.email
       fill_in 'Password', with: user2.password
@@ -29,19 +29,19 @@ RSpec.describe 'Admin CRUD', type: :system do
 
     it 'Delete user' do
       sign_in user
-      visit '/admin/users'
+      visit admin_users_path
 
       click_on 'Destroy'
       page.accept_alert
 
-      expect(page).to have_current_path('/users/sign_in')
+      expect(page).to have_current_path(new_user_session_path)
     end
 
     it 'edit user' do
       user3 = create(:user)
 
       sign_in user
-      visit "/admin/users/#{user3.id}/edit"
+      visit edit_admin_user_path(user3)
 
       fill_in 'Password', with: user3.password
       fill_in 'Phone', with: 123_456_789
@@ -54,7 +54,7 @@ RSpec.describe 'Admin CRUD', type: :system do
     it 'list users without id' do
       sign_in user
 
-      visit '/admin/users'
+      visit admin_users_path
 
       expect(page).to have_text(user.email)
       expect(page).not_to have_text(user.id)

--- a/backend/spec/system/admin_spec.rb
+++ b/backend/spec/system/admin_spec.rb
@@ -9,17 +9,17 @@ RSpec.describe 'Admin', type: :system do
   describe 'When user is logged' do
     it 'goes to admin page' do
       sign_in user
-      visit '/admin'
+      visit admin_root_path
 
-      expect(page).to have_current_path('/admin')
+      expect(page).to have_current_path(admin_root_path)
     end
   end
 
   describe 'When user is not logged' do
     it 'does log in' do
-      visit '/admin'
+      visit admin_root_path
 
-      expect(page).to have_current_path('/users/sign_in')
+      expect(page).to have_current_path(new_user_session_path)
     end
   end
 end

--- a/backend/spec/system/option_crud_spec.rb
+++ b/backend/spec/system/option_crud_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Option CRUD', type: :system do
       let!(:option) { create(:option) }
 
       it 'creates the option' do
-        visit '/admin/options/new'
+        visit new_admin_option_path
 
         find('label', text: 'Question').click
         find('.option', text: question.name).click
@@ -30,7 +30,7 @@ RSpec.describe 'Option CRUD', type: :system do
       it 'list the options' do
         option = create(:option)
 
-        visit '/admin/options'
+        visit admin_options_path
 
         expect(page).to have_text(option.option_type)
       end
@@ -40,7 +40,7 @@ RSpec.describe 'Option CRUD', type: :system do
       it 'deletes the option' do
         create(:option)
 
-        visit '/admin/options'
+        visit admin_options_path
 
         click_on 'Destroy'
         page.accept_alert

--- a/backend/spec/system/question_crud_spec.rb
+++ b/backend/spec/system/question_crud_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe 'Question CRUD', type: :system do
 
       context 'when create' do
         before do
-          visit '/admin/questions/new'
+          visit new_admin_question_path
 
           find('label', text: 'Question type').click
           find('.option', text: question_type.name).click
@@ -36,7 +36,7 @@ RSpec.describe 'Question CRUD', type: :system do
 
       describe 'index' do
         before do
-          visit '/admin/questions'
+          visit admin_questions_path
         end
 
         it 'list the questions without id' do
@@ -57,7 +57,7 @@ RSpec.describe 'Question CRUD', type: :system do
 
       describe 'delete' do
         before do
-          visit '/admin/questions'
+          visit admin_questions_path
 
           first(:link, 'Destroy').click
 
@@ -77,7 +77,7 @@ RSpec.describe 'Question CRUD', type: :system do
 
       describe 'create' do
         before do
-          visit '/admin/questions/new'
+          visit new_admin_question_path
 
           find('label', text: 'Question type').click
           find('.option', text: question_type.name).click
@@ -97,7 +97,7 @@ RSpec.describe 'Question CRUD', type: :system do
 
       describe 'index' do
         before do
-          visit '/admin/questions'
+          visit admin_questions_path
         end
 
         it 'list the questions without id' do
@@ -113,7 +113,7 @@ RSpec.describe 'Question CRUD', type: :system do
 
       context 'when delete' do
         before do
-          visit '/admin/questions'
+          visit admin_questions_path
 
           click_on 'Destroy'
 

--- a/backend/spec/system/question_type_crud_spec.rb
+++ b/backend/spec/system/question_type_crud_spec.rb
@@ -12,13 +12,13 @@ RSpec.describe 'question_type CRUD', type: :system do
       end
 
       it 'list question_type' do
-        visit '/admin/question_types/'
+        visit admin_question_types_path
 
         expect(page).to have_text(question_type.name)
       end
 
       it 'Delete question_type' do
-        visit '/admin/question_types'
+        visit admin_question_types_path
 
         click_on 'Destroy'
         page.accept_alert

--- a/backend/spec/system/role_crud_spec.rb
+++ b/backend/spec/system/role_crud_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe 'Role CRUD', type: :system do
 
     describe 'list' do
       it 'visits roles' do
-        visit '/admin/roles'
+        visit admin_roles_path
 
         expect(page).to have_content 'Role'
       end
@@ -17,7 +17,7 @@ RSpec.describe 'Role CRUD', type: :system do
 
     describe 'destroy' do
       it 'cannot destroy role' do
-        visit '/admin/roles'
+        visit admin_roles_path
 
         click_on 'Destroy'
         page.accept_alert

--- a/backend/spec/system/sign_in_spec.rb
+++ b/backend/spec/system/sign_in_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe 'User sign in', type: :system do
 
   describe 'When data is valid' do
     before do
-      visit '/users/sign_in'
+      visit new_user_session_path
       fill_in 'Email', with: user.email
       fill_in 'Password', with: user.password
 
@@ -19,13 +19,13 @@ RSpec.describe 'User sign in', type: :system do
 
   describe 'When data is not valid' do
     it 'does not log in' do
-      visit '/users/sign_in'
+      visit new_user_session_path
       fill_in 'Email', with: user.email
       fill_in 'Password', with: 'invalid password'
 
       click_on 'Log in'
 
-      expect(page).to have_current_path('/users/sign_in')
+      expect(page).to have_current_path(new_user_session_path)
     end
   end
 end

--- a/backend/spec/system/survey_crud_spec.rb
+++ b/backend/spec/system/survey_crud_spec.rb
@@ -14,7 +14,7 @@ RSpec.describe 'Survey CRUD', type: :system do
 
       describe 'create' do
         it 'creates the survey' do
-          visit '/admin/surveys/new'
+          visit new_admin_survey_path
 
           find('label', text: 'User').click
           find('.option', text: user_admin.email).click
@@ -26,7 +26,7 @@ RSpec.describe 'Survey CRUD', type: :system do
 
       describe 'list' do
         it 'list the surveys' do
-          visit '/admin/surveys'
+          visit  admin_surveys_path
 
           expect(page).to have_text(survey.name)
         end
@@ -34,7 +34,7 @@ RSpec.describe 'Survey CRUD', type: :system do
 
       describe 'delete' do
         it 'deletes the survey' do
-          visit '/admin/surveys'
+          visit admin_surveys_path
 
           click_on 'Destroy'
           page.accept_alert
@@ -45,7 +45,7 @@ RSpec.describe 'Survey CRUD', type: :system do
 
       describe 'edit' do
         it 'can edit user' do
-          visit edit_admin_survey_path survey.id
+          visit edit_admin_survey_path(survey)
           expect(page).to have_selector '#survey_user_id', visible: :hidden
         end
       end
@@ -61,7 +61,7 @@ RSpec.describe 'Survey CRUD', type: :system do
 
       describe 'create' do
         it 'creates the survey' do
-          visit '/admin/surveys/new'
+          visit new_admin_survey_path
 
           click_button 'Create Survey'
           expect(page).to have_content 'Survey was successfully created.'
@@ -70,7 +70,7 @@ RSpec.describe 'Survey CRUD', type: :system do
 
       describe 'list' do
         before do
-          visit '/admin/surveys'
+          visit admin_surveys_path
         end
 
         it 'see surveys that belongs to him' do
@@ -84,14 +84,14 @@ RSpec.describe 'Survey CRUD', type: :system do
 
       describe 'show' do
         it 'can see his own survey' do
-          visit "/admin/surveys/#{survey1.id}"
+          visit admin_survey_path(survey1)
 
           expect(page).to have_text(survey1.name)
           expect(page).not_to have_text(survey.id)
         end
 
         it "can't see surveys that not belongs to him" do
-          visit "/admin/surveys/#{survey2.id}"
+          visit admin_survey_path(survey2)
 
           expect(page).to have_text("The page you were looking for doesn't exist.")
         end
@@ -99,7 +99,7 @@ RSpec.describe 'Survey CRUD', type: :system do
 
       describe 'edit' do
         it "can't edit user" do
-          visit edit_admin_survey_path survey1.id
+          visit edit_admin_survey_path(survey1)
           expect(page).not_to have_selector '#survey_user_id', visible: :hidden
         end
       end

--- a/backend/spec/system/users_crud_spec.rb
+++ b/backend/spec/system/users_crud_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe 'Role CRUD', type: :system do
 
       describe 'index' do
         before do
-          visit '/admin/users'
+          visit admin_users_path
         end
 
         it 'sees all users' do
@@ -27,7 +27,7 @@ RSpec.describe 'Role CRUD', type: :system do
 
       describe 'edit' do
         before do
-          visit edit_admin_user_path user_admin
+          visit edit_admin_user_path(user_admin)
         end
 
         it 'does see role' do
@@ -47,7 +47,7 @@ RSpec.describe 'Role CRUD', type: :system do
         end
 
         it 'is at admin/users page' do
-          expect(page).to have_current_path('/admin/users')
+          expect(page).to have_current_path(admin_users_path)
         end
 
         it 'sees himself' do
@@ -61,7 +61,7 @@ RSpec.describe 'Role CRUD', type: :system do
 
       describe 'edit' do
         before do
-          visit edit_admin_user_path user_teacher
+          visit edit_admin_user_path(user_teacher)
         end
 
         it 'does not see role' do


### PR DESCRIPTION
# Paths

**Rspec:**
- Change almost all paths from hard-coded to rails helper paths.
- Change for example from "user.id" to "user" in rails helper paths.

**Nice to have:**
- spec/requests/surveys_request_spec.rb:60, A better way how to write this api_v1_surveys_path << "?user_id=#{another_user.id}"

_Thanks for taking the time to review my PR_ 😄 


fix #149 