### PR TITLE
Improve performance speed.

### DIFF
--- a/backend/app/models/option.rb
+++ b/backend/app/models/option.rb
@@ -11,6 +11,6 @@ class Option < ApplicationRecord
   def validates_correct
     correct_options_positive = question&.options&.correct&.any?
     # i18n-tasks-use t('activerecord.errors.models.option.attributes.base.cant_create_option')
-    errors.add(:base, :cant_create_option) if correct_options_positive && question.single_choice? && correct
+    errors.add(:base, :cant_create_option) if correct && question.single_choice? && correct_options_positive
   end
 end

--- a/backend/app/models/question.rb
+++ b/backend/app/models/question.rb
@@ -6,7 +6,7 @@ class Question < ApplicationRecord
   belongs_to :survey, optional: true
   has_many :options, dependent: :destroy
 
-  delegate :single_choice?, to: :question_type
+  delegate :single_choice?, to: :question_type, allow_nil: true
 
   scope :by_user, lambda { |user|
     return all.includes([:options]) if user.admin?
@@ -19,6 +19,6 @@ class Question < ApplicationRecord
   def validates_options
     many_correct_options = options.correct.count > 1
     # i18n-tasks-use t('activerecord.errors.models.question.attributes.question_type.cant_change_question_type')
-    errors.add(:question_type, :cant_change_question_type) if many_correct_options && single_choice?
+    errors.add(:question_type, :cant_change_question_type) if single_choice? && many_correct_options
   end
 end

--- a/backend/app/models/survey.rb
+++ b/backend/app/models/survey.rb
@@ -3,8 +3,8 @@ class Survey < ApplicationRecord
   has_many :questions, dependent: :nullify
 
   scope :by_user, lambda { |user|
-    return Survey.where(user_id: user).includes([:questions]) unless user.admin?
+    return where(user_id: user).includes([:questions]) unless user.admin?
 
-    Survey.all.includes([:questions])
+    all.includes([:questions])
   }
 end


### PR DESCRIPTION
# Improved performance!

**OptionModel:**
- Change order of statement in validates_correct validation.

**QuestionModel:**
- Change order of statement in validates_options.
- Add "allow_nil" to delegate as it will check single choice first before it checks correct options.

**SurveyModel:**
- Remove unnecessary "Survey" from scope "by_user".

### **PerformanceOrder:**
**OptionModel:**
- First check if option is marked as correct which is the fastest.
- Second check if the question_type of the question that belongs to that option is a single choice as it only compares name (no queries).
- Last check if the question has any correct options (worst case scenario it have to go through the whole database of options connected to that question).

**QuestionModel:**
- First check if the question type is a single choice as it is only two options atm.
- Second do the count to see how many correct options there are.

_Thank you for taking the time to review my PR!,_ 😄 
_This was a very interesting issue which changed my way of coding for the rest of my life! Thanks a lot, Edimo!_


fix #217 