### PR TITLE
Add ready_to_be_answered flag to question

### DIFF
--- a/backend/app/dashboards/question_dashboard.rb
+++ b/backend/app/dashboards/question_dashboard.rb
@@ -13,6 +13,7 @@ class QuestionDashboard < ApplicationDashboard
     survey: BelongsToByUser,
     options: Field::HasMany,
     name: Field::String,
+    ready_to_be_answered: Field::Boolean,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
   }.freeze
@@ -26,6 +27,7 @@ class QuestionDashboard < ApplicationDashboard
     name
     question_type
     survey
+    ready_to_be_answered
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -36,6 +38,7 @@ class QuestionDashboard < ApplicationDashboard
     survey
     name
     options
+    ready_to_be_answered
   ].freeze
 
   # FORM_ATTRIBUTES
@@ -47,6 +50,7 @@ class QuestionDashboard < ApplicationDashboard
     survey
     name
     options
+    ready_to_be_answered
   ].freeze
 
   # COLLECTION_FILTERS

--- a/backend/app/models/option.rb
+++ b/backend/app/models/option.rb
@@ -3,14 +3,30 @@ class Option < ApplicationRecord
   belongs_to :question
   validates :name, presence: true
   validate :validates_correct
+  validate :validates_ready
 
   scope :correct, -> { where(correct: true) }
+
+  delegate :single_choice?, to: :question, allow_nil: true
 
   private
 
   def validates_correct
     correct_options_positive = question&.options&.correct&.any?
     # i18n-tasks-use t('activerecord.errors.models.option.attributes.base.cant_create_option')
-    errors.add(:base, :cant_create_option) if correct && question.single_choice? && correct_options_positive
+    return if correct_was
+
+    errors.add(:base, :cant_create_option) if correct && single_choice? && correct_options_positive
+  end
+
+  def validates_ready
+    one_question = question&.options&.correct&.one?
+    # i18n-tasks-use t('activerecord.errors.models.option.attributes.correct.cant_update_correct')
+
+    errors.add(:correct, :cant_update_correct) if correct_state_valid? && question&.ready_to_be_answered && one_question
+  end
+
+  def correct_state_valid?
+    correct_was && !correct
   end
 end

--- a/backend/app/models/question.rb
+++ b/backend/app/models/question.rb
@@ -1,6 +1,7 @@
 class Question < ApplicationRecord
   validates :name, presence: true, uniqueness: { scope: :user_id }
   validate :validates_options
+  validate :validates_ready
   belongs_to :user
   belongs_to :question_type
   belongs_to :survey, optional: true
@@ -20,5 +21,10 @@ class Question < ApplicationRecord
     many_correct_options = options.correct.count > 1
     # i18n-tasks-use t('activerecord.errors.models.question.attributes.question_type.cant_change_question_type')
     errors.add(:question_type, :cant_change_question_type) if single_choice? && many_correct_options
+  end
+
+  def validates_ready
+    # i18n-tasks-use t('activerecord.errors.models.question.attributes.base.not_ready_question')
+    errors.add(:base, :not_ready_question) if ready_to_be_answered && options.correct.none?
   end
 end

--- a/backend/config/locales/en.yml
+++ b/backend/config/locales/en.yml
@@ -7,8 +7,12 @@ en:
           attributes:
             base:
               cant_create_option: Single choice questions should have no more than one correct option.
+            correct:
+              cant_update_correct: Can't change to false when question is ready to be answered.
         question:
           attributes:
+            base:
+              not_ready_question: Question needs at least one correct option to be ready.
             question_type:
               cant_change_question_type: Can't change to single choice when having more than one correct option.
         question_type:

--- a/backend/config/locales/pt-br.yml
+++ b/backend/config/locales/pt-br.yml
@@ -7,8 +7,12 @@ pt-br:
           attributes:
             base:
               cant_create_option: As perguntas de escolha única não devem ter mais do que uma opção correta.
+            correct:
+              cant_update_correct: Não pode mudar para falso quando a pergunta está pronta para ser respondida.
         question:
           attributes:
+            base:
+              not_ready_question: Pergunta precisa de pelo menos uma opção correta para estar pronta.
             question_type:
               cant_change_question_type: Não é possível mudar para uma única escolha quando há mais de uma opção correta.
         question_type:

--- a/backend/db/migrate/20210605072113_add_column_to_questions.rb
+++ b/backend/db/migrate/20210605072113_add_column_to_questions.rb
@@ -1,0 +1,5 @@
+class AddColumnToQuestions < ActiveRecord::Migration[6.1]
+  def change
+    add_column :questions, :ready_to_be_answered, :boolean, default: false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_05_31_082114) do
+ActiveRecord::Schema.define(version: 2021_06_05_072113) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,6 +40,7 @@ ActiveRecord::Schema.define(version: 2021_05_31_082114) do
     t.integer "question_type_id", null: false
     t.integer "survey_id"
     t.integer "user_id", null: false
+    t.boolean "ready_to_be_answered", default: false
     t.index ["name", "user_id"], name: "index_questions_on_name_and_user_id", unique: true
     t.index ["question_type_id"], name: "index_questions_on_question_type_id"
     t.index ["survey_id"], name: "index_questions_on_survey_id"

--- a/backend/spec/factories/options.rb
+++ b/backend/spec/factories/options.rb
@@ -4,4 +4,8 @@ FactoryBot.define do
     association :question
     association :user
   end
+
+  factory :correct_option, parent: :option do
+    correct { true }
+  end
 end

--- a/backend/spec/factories/questions.rb
+++ b/backend/spec/factories/questions.rb
@@ -13,4 +13,12 @@ FactoryBot.define do
   factory :multiple_choice_question, parent: :question do
     question_type { create(:question_type_multiple) }
   end
+
+  factory :multiple_choice_ready_question, parent: :multiple_choice_question do
+    after(:create) do |question|
+      create(:correct_option, question: question)
+      question.ready_to_be_answered = true
+      question.save
+    end
+  end
 end

--- a/backend/spec/models/option_spec.rb
+++ b/backend/spec/models/option_spec.rb
@@ -2,7 +2,10 @@ require 'rails_helper'
 
 RSpec.describe Option, type: :model do
   let!(:question_single) { create(:single_choice_question) }
-  let!(:option) { build(:option, question_id: question_single.id, correct: true) }
+  let!(:ready_question) { create(:single_choice_question) }
+  let!(:correct_option) { create(:correct_option, question: ready_question) }
+  let!(:test_option) { build(:option, question_id: question_single.id, correct: true) }
+  let!(:option) { create(:option, correct: true, question_id: question_single.id) }
 
   it { expect(option).to be_valid }
 
@@ -17,22 +20,68 @@ RSpec.describe Option, type: :model do
 
   describe 'option validation' do
     before do
-      create(:option, correct: true, question_id: question_single.id)
-      option.valid?
+      test_option.valid?
+      ready_question.update(ready_to_be_answered: true)
     end
 
     describe 'when many options are set to correct' do
-      it { expect(option.errors.full_messages).to match(['Single choice questions should have no more than one correct option.']) }
-      it { expect(option).not_to be_valid }
+      it { expect(test_option.errors.full_messages).to match(['Single choice questions should have no more than one correct option.']) }
+      it { expect(test_option).not_to be_valid }
+      it { expect(option.update(name: 'new name')).to be_truthy }
+      it { expect(option.errors).to be_empty }
+    end
+
+    describe 'when update option of ready question' do
+      it { expect(ready_question.ready_to_be_answered).to eq(true) }
+      it { expect(correct_option.update(correct: false)).to be_falsy }
     end
   end
 
   describe 'scopes' do
     before do
+      described_class.destroy_all
       create_list(:option, 2)
       create_list(:option, 3, correct: true)
     end
 
     it { expect(described_class.correct.count).to eq(3) }
+  end
+
+  describe '#validates_correct' do
+    let!(:question) { create(:single_choice_question) }
+    let!(:option) { create(:correct_option, question: question) }
+    let(:option2) { build(:correct_option, question: question) }
+
+    it 'is valid when there is only one correct option for single_choice question' do
+      expect(option).to be_valid
+    end
+
+    it 'is not valid when there are many correct option for single_choice question' do
+      expect(option2).not_to be_valid
+    end
+  end
+
+  describe '#validates_ready' do
+    let!(:question) { create(:multiple_choice_ready_question) }
+    let!(:option) { question.options.first }
+
+    describe 'when question is ready' do
+      describe 'and there is only one correct option' do
+        it 'the option cannot have correct false' do
+          option.correct = false
+
+          expect(option).not_to be_valid
+        end
+      end
+
+      describe 'and there are many correct options' do
+        it 'one of the options can have correct false' do
+          create(:correct_option, question: question)
+          option.correct = false
+
+          expect(option).to be_valid
+        end
+      end
+    end
   end
 end

--- a/backend/spec/models/question_spec.rb
+++ b/backend/spec/models/question_spec.rb
@@ -47,4 +47,15 @@ RSpec.describe Question, type: :model do
     it { expect(described_class.by_user(user_admin)).to include(question_single, question, question_multiple, question_teacher) }
     it { expect(described_class.by_user(user_moderator)).to eq([]) }
   end
+
+  describe '#validates_ready' do
+    it 'has no correct options' do
+      expect(question.update(ready_to_be_answered: true)).to eq(false)
+    end
+
+    it 'has correct options ' do
+      create(:correct_option, question: question)
+      expect(question.update(ready_to_be_answered: true)).to eq(true)
+    end
+  end
 end


### PR DESCRIPTION
# ReadyToBeAnswered

**QuestionModel:**
- Add ready_to_be_answered flag with default false.
- Add validates_ready validation to check if question have any correct options before updating the ready_to_be_answered flag.

**OptionModel:**
- Add "correct_was" in the statement of validates_correct to avoid issues when updating the name of a correct option.
- Add validates_ready validation with the validate_helper method to avoid updating the option to false when the question is ready_to_be_answered.
- Add validate_helper method to avoid PerceivedComplexity in rubocop.

**QuestionDashboard:**
- Add ready_to_be_answered column to the dashboard.

**Translations:**
- Add translated message for cant_update_correct.
- Add translated message for not_ready_question.

## **Rspec**
**OptionFactory:**
- Add correct_option with correct set to true.

**Option_spec.rb:**
- Add test to check if update correct option returns true.
- Add test to check that the correct option after the update has no errors.
- Add test to return false when update option correct to true when question is ready_to_be_answered.

**Question_spec.rb:**
- Add test to return false when try to update ready_to_be_answered to true when there are no correct options.
- Add test to return true when update ready_to_be_answered to true when there is a correct option.

_Thanks for taking the time to review my PR!_ 😄 
_The "correct_was" gives you the previous state of the attribute when updating!_
