### PR TITLE
223 - add missing methods to application policy

### DIFF
--- a/backend/app/policies/application_policy.rb
+++ b/backend/app/policies/application_policy.rb
@@ -28,6 +28,10 @@ class ApplicationPolicy
     admin?
   end
 
+  def update?
+    admin?
+  end
+
   def destroy?
     admin?
   end

--- a/backend/spec/system/question_type_crud_spec.rb
+++ b/backend/spec/system/question_type_crud_spec.rb
@@ -39,6 +39,16 @@ RSpec.describe 'question_type CRUD', type: :system do
 
         it { expect(page).to have_text('Question type was successfully created.') }
       end
+
+      describe 'when edit' do
+        before do
+          question_type = create(:question_type)
+          visit edit_admin_question_type_path(question_type)
+          click_button 'Update Question type'
+        end
+
+        it { expect(page).to have_text('Question type was successfully updated.') }
+      end
     end
   end
 end

--- a/backend/spec/system/role_crud_spec.rb
+++ b/backend/spec/system/role_crud_spec.rb
@@ -8,11 +8,11 @@ RSpec.describe 'Role CRUD', type: :system do
       visit admin_roles_path
     end
 
-    describe 'list' do
+    describe 'when list' do
       it { expect(page).to have_content 'Role' }
     end
 
-    describe 'destroy' do
+    describe 'when destroy' do
       before do
         click_on 'Destroy'
         page.accept_alert
@@ -29,6 +29,16 @@ RSpec.describe 'Role CRUD', type: :system do
       end
 
       it { expect(page).to have_text('Role was successfully created.') }
+    end
+
+    describe 'when edit' do
+      before do
+        role = create(:role_admin)
+        visit edit_admin_role_path(role)
+        click_button 'Update Role'
+      end
+
+      it { expect(page).to have_text('Role was successfully updated.') }
     end
   end
 end


### PR DESCRIPTION
fix #223

**Policies:**
- add missing method `update?` to Application policy

### Rspec
**System:**
- Add tests to update `Role` and `QuestionType`.

#### Only select the appropriate.
- [ ] **Model testing.**
- [ ] **Request testing.**
- [x] **System testing.**
- [ ] **No tests required.**


