### PR TITLE
Configure sentry  204

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -68,7 +68,8 @@ gem 'devise-i18n'
 gem 'devise-bootstrap-views', '~> 1.0'
 gem 'devise-jwt', '~> 0.7.0'
 gem 'rack-cors'
-
+gem "sentry-ruby"
+gem "sentry-rails"
 gem 'active_model_serializers'
 
 gem "pundit"

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -148,6 +148,19 @@ GEM
     factory_bot_rails (6.2.0)
       factory_bot (~> 6.2.0)
       railties (>= 5.0.0)
+    faraday (1.4.2)
+      faraday-em_http (~> 1.0)
+      faraday-em_synchrony (~> 1.0)
+      faraday-excon (~> 1.1)
+      faraday-net_http (~> 1.0)
+      faraday-net_http_persistent (~> 1.1)
+      multipart-post (>= 1.2, < 3)
+      ruby2_keywords (>= 0.0.4)
+    faraday-em_http (1.0.0)
+    faraday-em_synchrony (1.0.0)
+    faraday-excon (1.1.0)
+    faraday-net_http (1.0.1)
+    faraday-net_http_persistent (1.1.0)
     ffi (1.15.1)
     globalid (0.4.2)
       activesupport (>= 4.2.0)
@@ -200,6 +213,7 @@ GEM
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     msgpack (1.4.2)
+    multipart-post (2.1.1)
     nio4r (2.5.7)
     nokogiri (1.11.6-x86_64-linux)
       racc (~> 1.4)
@@ -313,6 +327,7 @@ GEM
       rubocop (~> 1.0)
       rubocop-ast (>= 1.1.0)
     ruby-progressbar (1.11.0)
+    ruby2_keywords (0.0.4)
     rubyzip (2.3.0)
     sass-rails (6.0.0)
       sassc-rails (~> 2.1, >= 2.1.1)
@@ -331,6 +346,16 @@ GEM
       rubyzip (>= 1.2.2)
       websocket (~> 1.0)
     semantic_range (3.0.0)
+    sentry-rails (4.5.1)
+      railties (>= 5.0)
+      sentry-ruby-core (~> 4.5.0)
+    sentry-ruby (4.5.1)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      faraday (>= 1.0)
+      sentry-ruby-core (= 4.5.1)
+    sentry-ruby-core (4.5.1)
+      concurrent-ruby
+      faraday
     shoulda-matchers (4.5.1)
       activesupport (>= 4.2.0)
     simplecov (0.21.2)
@@ -422,6 +447,8 @@ DEPENDENCIES
   rubocop-rspec
   sass-rails (>= 6)
   selenium-webdriver (= 4.0.0.beta1)
+  sentry-rails
+  sentry-ruby
   shoulda-matchers (~> 4.0)
   simplecov
   slim

--- a/backend/config/initializers/sentry.rb
+++ b/backend/config/initializers/sentry.rb
@@ -1,0 +1,14 @@
+Sentry.init do |config|
+    config.dsn = ENV["SENTRY_KEY"]
+    config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+  
+    # Set tracesSampleRate to 1.0 to capture 100%
+    # of transactions for performance monitoring.
+    # We recommend adjusting this value in production
+    config.traces_sample_rate = 1.0
+    # or
+    # config.traces_sampler = lambda do |context|
+    #   true
+    # end
+  end
+  


### PR DESCRIPTION
fix #204 
# Configure Sentry
- Add sentry.rb file to initializers.
- Add sentry gems to gemfile.
- Add SENTRY_KEY to ENV variable.

#### Only select the appropriate.
- [ ] **Model testing.**
- [ ] **Request testing.**
- [ ] **System testing.**
- [x] **No tests required.**


