### PR TITLE
Add endpoint for ready surveys to index method

### DIFF
--- a/backend/app/controllers/api/v1/surveys_controller.rb
+++ b/backend/app/controllers/api/v1/surveys_controller.rb
@@ -6,7 +6,7 @@ class Api::V1::SurveysController < Api::V1::ApiController
   end
 
   def index
-    surveys = Survey.by_user(current_user).where(params.permit(:user_id))
+    surveys = Survey.ready_surveys.by_user(current_user).where(params.permit(:user_id))
 
     render json: surveys
   end

--- a/backend/app/dashboards/survey_dashboard.rb
+++ b/backend/app/dashboards/survey_dashboard.rb
@@ -9,6 +9,7 @@ class SurveyDashboard < ApplicationDashboard
     user: Field::BelongsTo,
     questions: HasManyByUser,
     name: Field::String,
+    ready: Field::Boolean,
     description: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
@@ -23,6 +24,7 @@ class SurveyDashboard < ApplicationDashboard
     user
     questions
     name
+    ready
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
@@ -32,6 +34,7 @@ class SurveyDashboard < ApplicationDashboard
     questions
     name
     description
+    ready
     created_at
     updated_at
   ].freeze
@@ -44,6 +47,7 @@ class SurveyDashboard < ApplicationDashboard
     questions
     name
     description
+    ready
   ].freeze
 
   # COLLECTION_FILTERS

--- a/backend/app/models/question.rb
+++ b/backend/app/models/question.rb
@@ -2,6 +2,7 @@ class Question < ApplicationRecord
   validates :name, presence: true, uniqueness: { scope: :user_id }
   validate :validates_options
   validate :validates_ready
+  validate :validates_ready_survey
 
   belongs_to :user
   belongs_to :question_type
@@ -29,5 +30,10 @@ class Question < ApplicationRecord
   def validates_ready
     # i18n-tasks-use t('activerecord.errors.models.question.attributes.base.not_ready_question')
     errors.add(:base, :not_ready_question) if ready_to_be_answered && options.correct.none?
+  end
+
+  def validates_ready_survey
+    # i18n-tasks-use t('activerecord.errors.models.question.attributes.ready_to_be_answered.cant_update_ready_to_be_answered')
+    errors.add(:ready_to_be_answered, :cant_update_ready_to_be_answered) if !ready_to_be_answered && survey&.ready
   end
 end

--- a/backend/app/models/survey.rb
+++ b/backend/app/models/survey.rb
@@ -1,4 +1,5 @@
 class Survey < ApplicationRecord
+  validate :validates_ready
   belongs_to :user
 
   has_many :questions, dependent: :nullify
@@ -9,4 +10,12 @@ class Survey < ApplicationRecord
 
     all.includes([:questions])
   }
+
+  scope :ready_surveys, -> { where(ready: true) }
+
+  def validates_ready
+    ready_questions = questions.all?(&:ready_to_be_answered)
+    # i18n-tasks-use t('activerecord.errors.models.survey.attributes.ready.cant_update_ready')
+    errors.add(:ready, :cant_update_ready) if ready && questions.any? && !ready_questions
+  end
 end

--- a/backend/config/locales/en.yml
+++ b/backend/config/locales/en.yml
@@ -15,6 +15,8 @@ en:
               not_ready_question: Question needs at least one correct option to be ready.
             question_type:
               cant_change_question_type: Can't change to single choice when having more than one correct option.
+            ready_to_be_answered:
+              cant_update_ready_to_be_answered: Has to be "ready to be answered" when survey is ready.
         question_type:
           attributes:
             questions:
@@ -23,6 +25,10 @@ en:
           attributes:
             users:
               cant_destroy_role: Can't destroy role with %{users_count} users
+        survey:
+          attributes:
+            ready:
+              cant_update_ready: All questions need to be ready to be answered before you can make the survey ready.
   admin:
     application:
       navigation:

--- a/backend/config/locales/pt-br.yml
+++ b/backend/config/locales/pt-br.yml
@@ -15,6 +15,8 @@ pt-br:
               not_ready_question: Pergunta precisa de pelo menos uma opção correta para estar pronta.
             question_type:
               cant_change_question_type: Não é possível mudar para uma única escolha quando há mais de uma opção correta.
+            ready_to_be_answered:
+              cant_update_ready_to_be_answered: Tem que estar "pronto para ser respondido" quando a pesquisa estiver pronta.
         question_type:
           attributes:
             questions:
@@ -23,6 +25,10 @@ pt-br:
           attributes:
             users:
               cant_destroy_role: Não é possível apagar função com %{users_count} usuários
+        survey:
+          attributes:
+            ready:
+              cant_update_ready: Todas as perguntas precisam estar prontas para serem respondidas antes de você preparar a pesquisa.
   admin:
     application:
       navigation:

--- a/backend/db/migrate/20210615093729_add_column_to_surveys.rb
+++ b/backend/db/migrate/20210615093729_add_column_to_surveys.rb
@@ -1,0 +1,5 @@
+class AddColumnToSurveys < ActiveRecord::Migration[6.1]
+  def change
+    add_column :surveys, :ready, :boolean, default: false
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_12_203004) do
+ActiveRecord::Schema.define(version: 2021_06_15_093729) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -81,6 +81,7 @@ ActiveRecord::Schema.define(version: 2021_06_12_203004) do
     t.bigint "user_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
+    t.boolean "ready", default: false
     t.index ["user_id"], name: "index_surveys_on_user_id"
   end
 

--- a/backend/spec/factories/questions.rb
+++ b/backend/spec/factories/questions.rb
@@ -14,6 +14,10 @@ FactoryBot.define do
     question_type { create(:question_type_multiple) }
   end
 
+  factory :question_with_correct_option, parent: :question do
+    options { create_list :correct_option, 1 }
+  end
+
   factory :multiple_choice_ready_question, parent: :multiple_choice_question do
     after(:create) do |question|
       create(:correct_option, question: question)

--- a/backend/spec/factories/surveys.rb
+++ b/backend/spec/factories/surveys.rb
@@ -5,4 +5,16 @@ FactoryBot.define do
     association :user
     questions { build_list :question, 1 }
   end
+
+  factory :not_ready_survey, parent: :survey do
+    questions { [build(:question_with_correct_option), create(:multiple_choice_ready_question)] }
+  end
+
+  factory :ready_survey, parent: :survey do
+    questions { create_list :multiple_choice_ready_question, 1 }
+    after(:create) do |survey|
+      survey.ready = true
+      survey.save
+    end
+  end
 end

--- a/backend/spec/models/question_spec.rb
+++ b/backend/spec/models/question_spec.rb
@@ -59,4 +59,21 @@ RSpec.describe Question, type: :model do
       expect(question.update(ready_to_be_answered: true)).to eq(true)
     end
   end
+
+  describe '#validates_ready_survey' do
+    let!(:survey) { create(:ready_survey) }
+
+    it 'is not valid when update ready to be answered when survey is ready' do
+      question = survey.questions.first
+      question.ready_to_be_answered = false
+      expect(question).not_to be_valid
+    end
+
+    it 'does not update ready to be answered when survey is ready' do
+      question = survey.questions.first
+      question.ready_to_be_answered = false
+      question.valid?
+      expect(question.errors.full_messages).to match(['Ready to be answered Has to be "ready to be answered" when survey is ready.'])
+    end
+  end
 end

--- a/backend/spec/models/survey_spec.rb
+++ b/backend/spec/models/survey_spec.rb
@@ -18,4 +18,35 @@ RSpec.describe Survey, type: :model do
     it { expect(described_class.by_user(admin)).to eq([survey_teacher, survey_admin]) }
     it { expect(described_class.by_user(moderator)).to eq([]) }
   end
+
+  describe '.ready_surveys' do
+    it 'only shows ready surveys' do
+      create(:ready_survey)
+      create_list(:survey, 3)
+      expect(described_class.ready_surveys.count).to eq(1)
+    end
+  end
+
+  describe '#validates_ready' do
+    let!(:survey) { create(:not_ready_survey) }
+
+    it "can't update ready if not all questions are ready" do
+      survey.ready = true
+      expect(survey).not_to be_valid
+    end
+
+    it 'Shows the correct error if not all questions are ready' do
+      survey.ready = true
+      survey.valid?
+      expect(survey.errors.full_messages).to match(['Ready All questions need to be ready to be answered before you can make the survey ready.'])
+    end
+
+    it 'can update ready when all questions are ready' do
+      not_ready_question = survey.questions.find_by(ready_to_be_answered: false)
+      not_ready_question.ready_to_be_answered = true
+      not_ready_question.save
+      survey.reload.ready = true
+      expect(survey).to be_valid
+    end
+  end
 end

--- a/backend/spec/requests/surveys_request_spec.rb
+++ b/backend/spec/requests/surveys_request_spec.rb
@@ -29,9 +29,9 @@ RSpec.describe 'SurveysController', type: :request do
   end
 
   describe '#index' do
-    context 'when can list all surveys' do
+    context 'when can list all ready surveys' do
       before do
-        create_list(:survey, 3)
+        create_list(:ready_survey, 3)
         get api_v1_surveys_path, headers: auth_headers
       end
 
@@ -53,10 +53,10 @@ RSpec.describe 'SurveysController', type: :request do
     context 'when list surveys by user id' do
       before do
         user = create(:user)
-        create(:survey, name: 'test 1', user_id: user.id)
-        create(:survey, name: 'test 2', user_id: user.id)
+        create(:ready_survey, name: 'test 1', user_id: user.id)
+        create(:ready_survey, name: 'test 2', user_id: user.id)
         another_user = create(:user)
-        create(:survey, name: 'test 1', user_id: another_user.id)
+        create(:ready_survey, name: 'test 1', user_id: another_user.id)
         get api_v1_surveys_path(user_id: another_user.id), headers: auth_headers
       end
 
@@ -68,11 +68,11 @@ RSpec.describe 'SurveysController', type: :request do
       let!(:admin) { create(:user) }
       let!(:teacher) { create(:user_teacher) }
       let!(:moderator) { create(:user_moderator) }
-      let!(:survey_teacher) { create(:survey, user_id: teacher.id) }
+      let!(:survey_teacher) { create(:ready_survey, user_id: teacher.id) }
 
       context 'when the user is an admin' do
         before do
-          create(:survey, user_id: admin.id)
+          create(:ready_survey, user_id: admin.id)
           get api_v1_surveys_path, headers: auth_headers
         end
 


### PR DESCRIPTION
fix #230

# Add Endpoint for Ready Surveys
### **Models:**
**QuestionModel:**
- Add "validates_ready_survey" validation when updating or creating question in ready survey.

**SurveyModel:**
- Add "Ready" flag to the survey model.
- Add "validates_ready" validation when updating the survey to check whether all questions are ready.
- Add "ready_surveys" scope to only show surveys were "ready: true".

### **Controllers:**
**SurveysController:**
- Add "ready_surveys" scope to Index endpoint.

**Dashboard:**
- Add "Ready" checkbox to the survey form.
- Add "Ready" Boolean to the survey index page.

## **TranslationKeys:**
- Add translation keys for the error in validates_ready_survey validation of the question model.
- Add translation keys for the error in validates_ready validation of the survey model.

### Rspec
**FactoryBot:**
- Add question_with_correct_option to question factory (without ready to be answered flag).
- Add not_ready_survey to survey factory.
- Add ready_survey to survey factory.

**Model:**
- Add tests for validates_ready_survey validation in question_spec.
- Add tests for ready_surveys scope in the survey_spec.
- Add tests for validates_ready validation in survey_spec.

**Requests:**
- Change all survey to ready_survey in the index method tests as our endpoint is based on ready_surveys.

#### Only select the appropriate.
- [x] **Model testing.**
- [x] **Request testing.**
- [ ] **System testing.**
- [ ] **No tests required.**

_Thanks for taking the time to review my PR!_
