### PR TITLE
Add HasManyByUser to dashboard

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -62,4 +62,4 @@ RSpec/MultipleExpectations:
   Max: 1
 
 RSpec/MultipleMemoizedHelpers:
-  Max: 9
+  Max: 11

--- a/backend/app/dashboards/question_dashboard.rb
+++ b/backend/app/dashboards/question_dashboard.rb
@@ -11,7 +11,7 @@ class QuestionDashboard < ApplicationDashboard
     ),
     question_type: Field::BelongsTo,
     survey: BelongsToByUser,
-    options: Field::HasMany,
+    options: HasManyByUser,
     name: Field::String,
     ready_to_be_answered: Field::Boolean,
     created_at: Field::DateTime,

--- a/backend/app/models/option.rb
+++ b/backend/app/models/option.rb
@@ -12,6 +12,12 @@ class Option < ApplicationRecord
 
   delegate :single_choice?, to: :question, allow_nil: true
 
+  scope :by_user, lambda { |user|
+    return where(user: user).includes([:answers]) unless user.admin?
+
+    all.includes([:answers])
+  }
+
   private
 
   def validates_correct

--- a/backend/spec/models/option_spec.rb
+++ b/backend/spec/models/option_spec.rb
@@ -6,6 +6,9 @@ RSpec.describe Option, type: :model do
   let!(:correct_option) { create(:correct_option, question: ready_question) }
   let!(:test_option) { build(:option, question_id: question_single.id, correct: true) }
   let!(:option) { create(:option, correct: true, question_id: question_single.id) }
+  let!(:user_admin) { create(:user) }
+  let!(:user_teacher) { create(:user_teacher) }
+  let!(:user_moderator) { create(:user_moderator) }
 
   it { expect(option).to be_valid }
 
@@ -44,7 +47,7 @@ RSpec.describe Option, type: :model do
     it { is_expected.to validate_uniqueness_of(:name).scoped_to(:question_id) }
   end
 
-  describe 'scopes' do
+  describe '.correct' do
     before do
       described_class.destroy_all
       create_list(:option, 2)
@@ -52,6 +55,15 @@ RSpec.describe Option, type: :model do
     end
 
     it { expect(described_class.correct.count).to eq(3) }
+  end
+
+  describe '.by_user' do
+    let!(:option_teacher) { create(:option, user: user_teacher) }
+    let!(:option_admin) { create(:option, user: user_admin) }
+
+    it { expect(described_class.by_user(user_teacher)).to eq([option_teacher]) }
+    it { expect(described_class.by_user(user_admin)).to include(option_teacher, option_admin) }
+    it { expect(described_class.by_user(user_moderator)).to eq([]) }
   end
 
   describe '#validates_correct' do

--- a/backend/spec/system/question_crud_spec.rb
+++ b/backend/spec/system/question_crud_spec.rb
@@ -7,6 +7,8 @@ RSpec.describe 'Question CRUD', type: :system do
     let!(:user_teacher) { create(:user_teacher) }
     let!(:survey_admin) { create(:survey, user: user_admin) }
     let!(:survey_teacher) { create(:survey, user: user_teacher) }
+    let!(:option_admin) { create(:option, user: user_admin) }
+    let!(:option_teacher) { create(:option, user: user_teacher) }
     let!(:question_admin) { create(:question, user: user_admin, survey: survey_admin) }
     let!(:question_teacher) { create(:question, user: user_teacher, survey: survey_teacher) }
     let!(:question_type) { create(:question_type) }
@@ -27,6 +29,11 @@ RSpec.describe 'Question CRUD', type: :system do
         it 'expect to show admin and teacher surveys' do
           find('label', text: 'Survey').click
           expect(page).to have_selector('.option', text: survey_admin.name && survey_teacher.name)
+        end
+
+        it 'expect to show admin and teacher options' do
+          find('label', text: 'Option').click
+          expect(page).to have_selector('.option', text: option_admin.name && option_teacher.name)
         end
 
         it 'shows user select when admin' do
@@ -116,6 +123,16 @@ RSpec.describe 'Question CRUD', type: :system do
         it 'shows only teacher surveys' do
           find('label', text: 'Survey').click
           expect(page).not_to have_selector('.option', text: survey_admin.name)
+        end
+
+        it 'does not show admin options' do
+          find('label', text: 'Option').click
+          expect(page).not_to have_selector('.option', text: option_admin.name)
+        end
+
+        it 'shows only teacher options' do
+          find('label', text: 'Option').click
+          expect(page).to have_selector('.option', text: option_teacher.name)
         end
 
         it 'does not show user select when not admin' do


### PR DESCRIPTION
fix #240 

# Options By User
**OptionModel:**
- Add ".by_user" scope, so we can use the same file for the option dashboard as for the question dashboard.

**QuestionDashboard:**
- Change HasMany field to HasManyByUser for options.

### Rspec

**Model:**
- Add tests for by_user scope for admin, teacher and moderator.

**System:**
- Add tests to only show options from current_user when creating question as teacher.
- Add tests to show all options when creating question as admin.

#### Only select the appropriate.
- [x] **Model testing.**
- [ ] **Request testing.**
- [x] **System testing.**
- [ ] **No tests required.**


