### PR TITLE
Add BelongsToByUser for question when creating option

### DIFF
--- a/backend/app/controllers/admin/options_controller.rb
+++ b/backend/app/controllers/admin/options_controller.rb
@@ -1,46 +1,7 @@
 module Admin
   class OptionsController < Admin::ApplicationController
-    # Overwrite any of the RESTful controller actions to implement custom behavior
-    # For example, you may want to send an email after a foo is updated.
-    #
-    # def update
-    #   super
-    #   send_foo_updated_email(requested_resource)
-    # end
-
-    # Override this method to specify custom lookup behavior.
-    # This will be used to set the resource for the `show`, `edit`, and `update`
-    # actions.
-    #
-    # def find_resource(param)
-    #   Foo.find_by!(slug: param)
-    # end
-
-    # The result of this lookup will be available as `requested_resource`
-
-    # Override this if you have certain roles that require a subset
-    # this will be used to set the records shown on the `index` action.
-    #
-    # def scoped_resource
-    #   if current_user.super_admin?
-    #     resource_class
-    #   else
-    #     resource_class.with_less_stuff
-    #   end
-    # end
-
-    # Override `resource_params` if you want to transform the submitted
-    # data before it's persisted. For example, the following would turn all
-    # empty values into nil values. It uses other APIs such as `resource_class`
-    # and `dashboard`:
-    #
-    # def resource_params
-    #   params.require(resource_class.model_name.param_key).
-    #     permit(dashboard.permitted_attributes).
-    #     transform_values { |value| value == "" ? nil : value }
-    # end
-
-    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
-    # for more information
+    def new_resource
+      resource_class.new(user: current_user)
+    end
   end
 end

--- a/backend/app/dashboards/option_dashboard.rb
+++ b/backend/app/dashboards/option_dashboard.rb
@@ -7,7 +7,7 @@ class OptionDashboard < ApplicationDashboard
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
     user: Field::BelongsTo,
-    question: Field::BelongsTo,
+    question: BelongsToByUser,
     id: Field::Number,
     name: Field::String,
     correct: Field::Boolean

--- a/backend/app/models/question.rb
+++ b/backend/app/models/question.rb
@@ -14,9 +14,9 @@ class Question < ApplicationRecord
   delegate :single_choice?, to: :question_type, allow_nil: true
 
   scope :by_user, lambda { |user|
-    return all.includes([:options]) if user.admin?
+    return where(user_id: user).includes([:options]) unless user.admin?
 
-    where(user_id: user).includes([:options])
+    all.includes([:options])
   }
 
   private

--- a/backend/spec/system/option_crud_spec.rb
+++ b/backend/spec/system/option_crud_spec.rb
@@ -5,6 +5,8 @@ RSpec.describe 'Option CRUD', type: :system do
   describe 'CRUD' do
     let!(:question) { create(:question) }
     let!(:user) { create(:user) }
+    let!(:teacher) { create(:user_teacher) }
+    let!(:question_teacher) { create(:question, user: teacher) }
     let!(:option) { create(:option) }
 
     before do
@@ -45,6 +47,28 @@ RSpec.describe 'Option CRUD', type: :system do
         end
 
         it { expect(page).to have_content 'Name has already been taken' }
+      end
+
+      context 'when admin shows all questions' do
+        before do
+          visit new_admin_option_path
+
+          find('label', text: 'Question').click
+        end
+
+        it { expect(page).to have_selector('.option', text: question_teacher.name && question.name) }
+      end
+
+      context 'when teacher only shows teacher questions' do
+        before do
+          sign_in teacher
+          visit new_admin_option_path
+
+          find('label', text: 'Question').click
+        end
+
+        it { expect(page).to have_selector('.option', text: question_teacher.name) }
+        it { expect(page).not_to have_selector('.option', text: question.name) }
       end
     end
 


### PR DESCRIPTION
fix #247 

# Add BelongsToByUser To Question In Option Dashboard

**OptionsController:**
- Add new_resource method with current_user as user.

**OptionDashboard:**
- Add BelongsToByUser to question.

### Rspec

**System:**
- Add tests to show all questions when admin.
- Add tests to only show teacher question when teacher.

#### Only select the appropriate.
- [ ] **Model testing.**
- [ ] **Request testing.**
- [x] **System testing.**
- [ ] **No tests required.**


