### PR TITLE
Create survey subject model and admin views

### DIFF
--- a/backend/app/controllers/admin/survey_subjects_controller.rb
+++ b/backend/app/controllers/admin/survey_subjects_controller.rb
@@ -1,0 +1,46 @@
+module Admin
+  class SurveySubjectsController < Admin::ApplicationController
+    # Overwrite any of the RESTful controller actions to implement custom behavior
+    # For example, you may want to send an email after a foo is updated.
+    #
+    # def update
+    #   super
+    #   send_foo_updated_email(requested_resource)
+    # end
+
+    # Override this method to specify custom lookup behavior.
+    # This will be used to set the resource for the `show`, `edit`, and `update`
+    # actions.
+    #
+    # def find_resource(param)
+    #   Foo.find_by!(slug: param)
+    # end
+
+    # The result of this lookup will be available as `requested_resource`
+
+    # Override this if you have certain roles that require a subset
+    # this will be used to set the records shown on the `index` action.
+    #
+    # def scoped_resource
+    #   if current_user.super_admin?
+    #     resource_class
+    #   else
+    #     resource_class.with_less_stuff
+    #   end
+    # end
+
+    # Override `resource_params` if you want to transform the submitted
+    # data before it's persisted. For example, the following would turn all
+    # empty values into nil values. It uses other APIs such as `resource_class`
+    # and `dashboard`:
+    #
+    # def resource_params
+    #   params.require(resource_class.model_name.param_key).
+    #     permit(dashboard.permitted_attributes).
+    #     transform_values { |value| value == "" ? nil : value }
+    # end
+
+    # See https://administrate-prototype.herokuapp.com/customizing_controller_actions
+    # for more information
+  end
+end

--- a/backend/app/dashboards/survey_subject_dashboard.rb
+++ b/backend/app/dashboards/survey_subject_dashboard.rb
@@ -1,4 +1,6 @@
-class SurveyDashboard < ApplicationDashboard
+require 'administrate/base_dashboard'
+
+class SurveySubjectDashboard < Administrate::BaseDashboard
   # ATTRIBUTE_TYPES
   # a hash that describes the type of each of the model's fields.
   #
@@ -6,11 +8,9 @@ class SurveyDashboard < ApplicationDashboard
   # which determines how the attribute is displayed
   # on pages throughout the dashboard.
   ATTRIBUTE_TYPES = {
-    user: Field::BelongsTo,
-    survey_subject: Field::BelongsTo,
-    questions: HasManyByUser,
+    surveys: Field::HasMany,
+    id: Field::Number,
     name: Field::String,
-    ready: Field::Boolean,
     description: Field::String,
     created_at: Field::DateTime,
     updated_at: Field::DateTime
@@ -22,22 +22,18 @@ class SurveyDashboard < ApplicationDashboard
   # By default, it's limited to four items to reduce clutter on index pages.
   # Feel free to add, remove, or rearrange items.
   COLLECTION_ATTRIBUTES = %i[
-    user
-    survey_subject
-    questions
+    surveys
     name
-    ready
+    description
   ].freeze
 
   # SHOW_PAGE_ATTRIBUTES
   # an array of attributes that will be displayed on the model's show page.
   SHOW_PAGE_ATTRIBUTES = %i[
-    user
-    survey_subject
-    questions
+    surveys
+    id
     name
     description
-    ready
     created_at
     updated_at
   ].freeze
@@ -46,12 +42,9 @@ class SurveyDashboard < ApplicationDashboard
   # an array of attributes that will be displayed
   # on the model's form (`new` and `edit`) pages.
   FORM_ATTRIBUTES = %i[
-    user
-    survey_subject
-    questions
+    surveys
     name
     description
-    ready
   ].freeze
 
   # COLLECTION_FILTERS
@@ -66,7 +59,10 @@ class SurveyDashboard < ApplicationDashboard
   #   }.freeze
   COLLECTION_FILTERS = {}.freeze
 
-  # Overwrite this method to customize how surveys are displayed
+  # Overwrite this method to customize how survey subjects are displayed
   # across all pages of the admin dashboard.
   #
+  def display_resource(survey_subject)
+    survey_subject.name
+  end
 end

--- a/backend/app/models/survey.rb
+++ b/backend/app/models/survey.rb
@@ -1,6 +1,7 @@
 class Survey < ApplicationRecord
   validate :validates_ready
   belongs_to :user
+  belongs_to :survey_subject
 
   has_many :questions, dependent: :nullify
   has_many :answers_surveys, dependent: :destroy

--- a/backend/app/models/survey_subject.rb
+++ b/backend/app/models/survey_subject.rb
@@ -1,0 +1,20 @@
+class SurveySubject < ApplicationRecord
+  has_many :surveys, dependent: :destroy
+
+  before_destroy :check_surveys_before_destroy, prepend: true
+
+  validates :name, :description, presence: true
+
+  private
+
+  def check_surveys_before_destroy
+    survey_count = Survey.where(survey_subject_id: id)
+
+    return unless survey_count.any?
+
+    # i18n-tasks-use t('activerecord.errors.models.survey_subject.attributes.surveys.cant_destroy_survey_subject')
+    errors.add(:surveys, :cant_destroy_survey_subject, survey_count: survey_count.count)
+
+    throw :abort
+  end
+end

--- a/backend/app/policies/survey_subject_policy.rb
+++ b/backend/app/policies/survey_subject_policy.rb
@@ -1,0 +1,2 @@
+class SurveySubjectPolicy < ApplicationPolicy
+end

--- a/backend/app/serializers/survey_serializer.rb
+++ b/backend/app/serializers/survey_serializer.rb
@@ -1,4 +1,4 @@
 class SurveySerializer < ActiveModel::Serializer
-  attributes :id, :name, :description
+  attributes :id, :name, :description, :survey_subject_id
   has_many :questions
 end

--- a/backend/config/locales/en.yml
+++ b/backend/config/locales/en.yml
@@ -29,6 +29,10 @@ en:
           attributes:
             ready:
               cant_update_ready: All questions need to be ready to be answered before you can make the survey ready.
+        survey_subject:
+          attributes:
+            surveys:
+              cant_destroy_survey_subject: Can't destroy survey subject with %{survey_count} surveys.
   admin:
     application:
       navigation:

--- a/backend/config/locales/pt-br.yml
+++ b/backend/config/locales/pt-br.yml
@@ -29,6 +29,10 @@ pt-br:
           attributes:
             ready:
               cant_update_ready: Todas as perguntas precisam estar prontas para serem respondidas antes de você preparar a pesquisa.
+        survey_subject:
+          attributes:
+            surveys:
+              cant_destroy_survey_subject: Não é possível destruir o assunto da pesquisa com %{survey_count} pesquisas.
   admin:
     application:
       navigation:

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -3,10 +3,11 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :users
-    resources :questions
-    resources :question_types
-    resources :surveys
     resources :roles
+    resources :survey_subjects
+    resources :surveys
+    resources :question_types
+    resources :questions
     resources :options
 
     root to: "users#index"

--- a/backend/db/migrate/20210621130716_create_survey_subjects.rb
+++ b/backend/db/migrate/20210621130716_create_survey_subjects.rb
@@ -1,0 +1,10 @@
+class CreateSurveySubjects < ActiveRecord::Migration[6.1]
+  def change
+    create_table :survey_subjects do |t|
+      t.string :name
+      t.string :description
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/migrate/20210621130819_add_subject_ref_to_surveys.rb
+++ b/backend/db/migrate/20210621130819_add_subject_ref_to_surveys.rb
@@ -1,0 +1,5 @@
+class AddSubjectRefToSurveys < ActiveRecord::Migration[6.1]
+  def change
+    add_reference :surveys, :survey_subject, null: false, foreign_key: true
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_15_093729) do
+ActiveRecord::Schema.define(version: 2021_06_21_130819) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -75,6 +75,13 @@ ActiveRecord::Schema.define(version: 2021_06_15_093729) do
     t.index ["role_type"], name: "index_roles_on_role_type", unique: true
   end
 
+  create_table "survey_subjects", force: :cascade do |t|
+    t.string "name"
+    t.string "description"
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+  end
+
   create_table "surveys", force: :cascade do |t|
     t.string "name"
     t.string "description"
@@ -82,6 +89,8 @@ ActiveRecord::Schema.define(version: 2021_06_15_093729) do
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.boolean "ready", default: false
+    t.bigint "survey_subject_id", null: false
+    t.index ["survey_subject_id"], name: "index_surveys_on_survey_subject_id"
     t.index ["user_id"], name: "index_surveys_on_user_id"
   end
 
@@ -102,5 +111,6 @@ ActiveRecord::Schema.define(version: 2021_06_15_093729) do
 
   add_foreign_key "options", "questions"
   add_foreign_key "options", "users"
+  add_foreign_key "surveys", "survey_subjects"
   add_foreign_key "users", "roles"
 end

--- a/backend/db/seeds.rb
+++ b/backend/db/seeds.rb
@@ -4,6 +4,7 @@ QuestionType.destroy_all
 Question.destroy_all
 Survey.destroy_all
 Option.destroy_all
+SurveySubject.destroy_all
 
 role_admin = Role.create(role_type: 'admin')
 role_teacher = Role.create(role_type: 'teacher')
@@ -13,14 +14,18 @@ user_admin = User.create(email: 'admin@gmail.com', password: '123456', role: rol
 user_teacher = User.create(email: 'teacher@gmail.com', password: '123456', role: role_teacher)
 user_student = User.create(email: 'student@gmail.com', password: '123456', role: role_student)
 
+animal_subject = SurveySubject.create(name: "Animal", description: "All the surveys contain questions related to animals.")
+
+
 question_type_single_choice = QuestionType.create(name: "Single Choice")
 question_type_multiple_choice = QuestionType.create(name: "Multiple Choice")
 
-survey_admin = Survey.create(name: 'Colors survey - Admin', user: user_admin)
-ready_survey_teacher = Survey.create(name: 'Animals survey - Teacher', user: user_teacher)
 
-Survey.create(name: 'Dog survey - Teacher', user: user_teacher)
-Survey.create(name: 'Bunny survey - Teacher', user: user_teacher)
+survey_admin = Survey.create(name: 'Colors survey - Admin', user: user_admin, survey_subject_id: animal_subject.id)
+ready_survey_teacher = Survey.create(name: 'Animals survey - Teacher', user: user_teacher, survey_subject_id: animal_subject.id)
+
+Survey.create(name: 'Dog survey - Teacher', user: user_teacher, survey_subject_id: animal_subject.id)
+Survey.create(name: 'Bunny survey - Teacher', user: user_teacher, survey_subject_id: animal_subject.id)
 
 question_1_survey_admin1 = Question.create(name: "What is your favorit color?", user: user_admin, survey: survey_admin, question_type: question_type_single_choice)
 Option.create(name: "Red", question: question_1_survey_admin1, user: user_admin)

--- a/backend/spec/factories/survey_subjects.rb
+++ b/backend/spec/factories/survey_subjects.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :survey_subject do
+    name { Faker::Name.unique.name }
+    description { Faker::Name.unique.name }
+  end
+end

--- a/backend/spec/factories/surveys.rb
+++ b/backend/spec/factories/surveys.rb
@@ -3,6 +3,7 @@ FactoryBot.define do
     name { Faker::Name.unique.name }
     description { Faker::Name.unique.name }
     association :user
+    association :survey_subject
     questions { build_list :question, 1 }
   end
 

--- a/backend/spec/models/survey_spec.rb
+++ b/backend/spec/models/survey_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe Survey, type: :model do
   describe 'relationships' do
     it { is_expected.to belong_to(:user).required }
+    it { is_expected.to belong_to(:survey_subject).required }
     it { is_expected.to have_many(:questions).dependent(:nullify) }
     it { is_expected.to have_many(:answers_surveys).dependent(:destroy) }
   end

--- a/backend/spec/models/survey_subject_spec.rb
+++ b/backend/spec/models/survey_subject_spec.rb
@@ -1,0 +1,40 @@
+require 'rails_helper'
+
+RSpec.describe SurveySubject, type: :model do
+  describe 'relationships' do
+    it { is_expected.to have_many(:surveys).dependent(:destroy) }
+  end
+
+  describe 'presence' do
+    it { is_expected.to validate_presence_of(:name) }
+    it { is_expected.to validate_presence_of(:description) }
+  end
+
+  describe '#destroy' do
+    describe 'When there are surveys for survey subject' do
+      let!(:survey_subject) { create(:survey).survey_subject }
+
+      before do
+        survey_subject.destroy
+      end
+
+      it 'does not destroy' do
+        expect(survey_subject.errors.full_messages.first).to match("Can't destroy survey subject with 1 surveys.")
+      end
+
+      it { expect(described_class.count).to eq(1) }
+    end
+
+    describe 'When there are no surveys for survey subject' do
+      let!(:survey_subject) { create(:survey_subject) }
+
+      before do
+        survey_subject.destroy
+      end
+
+      it 'does not have any survey subject when delete survey subject' do
+        expect(described_class.count).to be_zero
+      end
+    end
+  end
+end

--- a/backend/spec/requests/surveys_request_spec.rb
+++ b/backend/spec/requests/surveys_request_spec.rb
@@ -5,6 +5,7 @@ RSpec.describe 'SurveysController', type: :request do
     let!(:survey) { create(:survey) }
     let!(:survey_question) { survey.questions.first }
     let!(:question_type) { survey_question.question_type }
+    let!(:survey_subject) { survey.survey_subject }
 
     before { get api_v1_survey_path(survey), headers: auth_headers }
 
@@ -15,6 +16,7 @@ RSpec.describe 'SurveysController', type: :request do
         'id' => anything,
         'name' => survey.name,
         'description' => survey.description,
+        'survey_subject_id' => survey_subject.id,
         'questions' => [
           'id' => survey_question.id,
           'name' => survey_question.name,

--- a/backend/spec/system/survey_crud_spec.rb
+++ b/backend/spec/system/survey_crud_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe 'Survey CRUD', type: :system do
     let!(:survey) { create(:survey) }
     let!(:question_admin) { create(:question, user: user_admin) }
     let!(:question_teacher) { create(:question, user: user_teacher) }
+    let!(:survey_subject) { create(:survey_subject) }
 
     describe 'when user is admin' do
       before do
@@ -22,6 +23,8 @@ RSpec.describe 'Survey CRUD', type: :system do
         it 'creates the survey for admin' do
           find('label', text: 'User').click
           find('.option', text: user_admin.email).click
+          find('label', text: 'Survey subject').click
+          find('.option', text: survey_subject.name).click
 
           click_button 'Create Survey'
           expect(page).to have_content 'Survey was successfully created.'
@@ -30,6 +33,8 @@ RSpec.describe 'Survey CRUD', type: :system do
         it 'creates the survey for teacher' do
           find('label', text: 'User').click
           find('.option', text: user_teacher.email).click
+          find('label', text: 'Survey subject').click
+          find('.option', text: survey_subject.name).click
 
           click_button 'Create Survey'
           expect(page).to have_content 'Survey was successfully created.'
@@ -83,6 +88,9 @@ RSpec.describe 'Survey CRUD', type: :system do
         end
 
         it 'creates survey' do
+          find('label', text: 'Survey subject').click
+          find('.option', text: survey_subject.name).click
+
           click_button 'Create Survey'
           expect(page).to have_content 'Survey was successfully created.'
         end

--- a/backend/spec/system/survey_subject_crud_spec.rb
+++ b/backend/spec/system/survey_subject_crud_spec.rb
@@ -1,0 +1,46 @@
+require 'rails_helper'
+
+RSpec.describe 'SurveySubject CRUD', type: :system do
+  include Devise::Test::IntegrationHelpers
+  describe 'CRUD' do
+    before do
+      create(:survey)
+      sign_in create(:user)
+      visit admin_survey_subjects_path
+    end
+
+    describe 'when list' do
+      it { expect(page).to have_content 'Survey Subjects' }
+    end
+
+    describe 'when destroy' do
+      before do
+        click_on 'Destroy'
+        page.accept_alert
+      end
+
+      it { expect(page).to have_content "Can't destroy survey subject with 1 surveys." }
+    end
+
+    describe 'when create' do
+      before do
+        click_on 'New survey subject'
+        fill_in 'Name', with: 'test subject'
+        fill_in 'Description', with: 'test Description'
+        click_button 'Create Survey subject'
+      end
+
+      it { expect(page).to have_text('Survey subject was successfully created.') }
+    end
+
+    describe 'when edit' do
+      before do
+        subject = create(:survey_subject)
+        visit edit_admin_survey_subject_path(subject)
+        click_button 'Update Survey subject'
+      end
+
+      it { expect(page).to have_text('Survey subject was successfully updated.') }
+    end
+  end
+end


### PR DESCRIPTION
fix #129 

# Add SurveySubject model
**SurveySubjectModel:**
- Add has many surveys, dependent destroy.
- Add validate presence for name and description.
- Add validation before destroy when trying to destroy with surveys.

**SurveyModel:**
- Add belongs to survey subject.

**Controllers:**
- Add the changes you did to the controller.
- Add anything else you did to the model.

**Routes:**
- Add routes for SurveySubject to admin namespace.

**SurveySubjectDashboard:**
- Add SurveySubject dashboard.

**SurveyDashboard:**
- Add SurveySubject BelongsTo field.

**Policies:**
- Add SurveySubjectPolicy and made it inherit from Applicationpolicy.

**SurveySerializer:**
- Add survey_subject_id to attributes.

**Translations:**
- Add Translation key for cant_destroy_survey_subject for survey_subject.

**Seeds:**
- Add SurveySubject to seeds.
- Add SurveySubject to all surveys.

### Rspec
**SurveySubjectFactory:**
- Add SurveySubject with initialize using find_or_create_by.

**SurveyFactory:**
- Add survey_subject association.

**SurveySubjectModel:**
- Add tests for associations.
- Add tests to validate the presence of name and description.
- Add tests for check_surveys_before_destroy validation.

**SurveyModel:**
- Add validation to belongs to SurveySubject.

**SurveyRequests:**
- SurveySubject to survey json attributes.

**SurveySubjectSystem:**
- Add tests for index.
- Add tests for create.
- Add tests for destroy.
- Add tests for update.

**SurveySystem:**
- Add SurveySubject when creating surveys.

#### Only select the appropriate.
- [x] **Model testing.**
- [x] **Request testing.**
- [x] **System testing.**
- [ ] **No tests required.**


