### PR TITLE
fix #170 must be the same user

### DIFF
--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -30,6 +30,7 @@ Metrics/AbcSize:
 
 Metrics/BlockLength:
   IgnoredMethods: ['describe', 'context']
+  Max: 35
 
 Metrics/ClassLength:
   Max: 200
@@ -59,7 +60,7 @@ RSpec/NestedGroups:
   Max: 4
 
 RSpec/MultipleExpectations:
-  Max: 1
+  Max: 2
 
 RSpec/MultipleMemoizedHelpers:
   Max: 11

--- a/backend/app/models/question.rb
+++ b/backend/app/models/question.rb
@@ -3,6 +3,7 @@ class Question < ApplicationRecord
   validate :validates_options
   validate :validates_ready
   validate :validates_ready_survey
+  validate :survey_must_have_same_user
 
   belongs_to :user
   belongs_to :question_type
@@ -20,6 +21,13 @@ class Question < ApplicationRecord
   }
 
   private
+
+  def survey_must_have_same_user
+    return unless user&.present? && survey&.present?
+
+    # i18n-tasks-use t('activerecord.errors.models.question.attributes.user_id.must_be_same_user')
+    errors.add(:user_id, :must_be_same_user) if user != survey.user
+  end
 
   def validates_options
     many_correct_options = options.correct.count > 1

--- a/backend/config/locales/en.yml
+++ b/backend/config/locales/en.yml
@@ -17,6 +17,8 @@ en:
               cant_change_question_type: Can't change to single choice when having more than one correct option.
             ready_to_be_answered:
               cant_update_ready_to_be_answered: Has to be "ready to be answered" when survey is ready.
+            user_id:
+              must_be_same_user: must be the same!
         question_type:
           attributes:
             questions:

--- a/backend/config/locales/pt-br.yml
+++ b/backend/config/locales/pt-br.yml
@@ -17,6 +17,8 @@ pt-br:
               cant_change_question_type: Não é possível mudar para uma única escolha quando há mais de uma opção correta.
             ready_to_be_answered:
               cant_update_ready_to_be_answered: Tem que estar "pronto para ser respondido" quando a pesquisa estiver pronta.
+            user_id:
+              must_be_same_user: deve ser o mesmo!
         question_type:
           attributes:
             questions:

--- a/backend/spec/factories/questions.rb
+++ b/backend/spec/factories/questions.rb
@@ -1,7 +1,6 @@
 FactoryBot.define do
   factory :question do
     name { Faker::Name.unique.name }
-    association :survey, questions: []
     association :question_type
     association :user
   end

--- a/backend/spec/factories/surveys.rb
+++ b/backend/spec/factories/surveys.rb
@@ -4,16 +4,33 @@ FactoryBot.define do
     description { Faker::Name.unique.name }
     association :user
     association :survey_subject
-    questions { build_list :question, 1 }
+
+    after(:create) do |survey|
+      survey.questions = build_list(:question, 1, user: survey.user)
+      survey.save
+    end
+  end
+
+  factory :survey_without_questions, parent: :survey do
+    after(:create) do |survey|
+      survey.questions = []
+      survey.save
+    end
   end
 
   factory :not_ready_survey, parent: :survey do
-    questions { [build(:question_with_correct_option), create(:multiple_choice_ready_question)] }
+    after(:create) do |survey|
+      survey.questions = [
+        build(:question_with_correct_option, user: survey.user),
+        create(:multiple_choice_ready_question, user: survey.user)
+      ]
+      survey.save
+    end
   end
 
   factory :ready_survey, parent: :survey do
-    questions { create_list :multiple_choice_ready_question, 1 }
     after(:create) do |survey|
+      survey.questions = create_list(:multiple_choice_ready_question, 1, user: survey.user, survey: survey)
       survey.ready = true
       survey.save
     end

--- a/backend/spec/models/question_spec.rb
+++ b/backend/spec/models/question_spec.rb
@@ -76,4 +76,21 @@ RSpec.describe Question, type: :model do
       expect(question.errors.full_messages).to match(['Ready to be answered Has to be "ready to be answered" when survey is ready.'])
     end
   end
+
+  describe 'validate survey same user' do
+    it 'is valid when question and survey have the same user' do
+      survey_teacher = create(:survey, user: user_teacher)
+      question = create(:question, user: user_teacher, survey: survey_teacher)
+
+      expect(question).to be_valid
+    end
+
+    it 'is not valid when question and survey have different user' do
+      survey_teacher = create(:survey, user: user_teacher)
+      question_mod = build(:question, user: user_moderator, survey: survey_teacher)
+
+      expect(question_mod).not_to be_valid
+      expect(question_mod.errors.full_messages).to match(['User must be the same!'])
+    end
+  end
 end


### PR DESCRIPTION
fix #170 

# Add Appropriate Title
**Models:**
- Add method survey_must_have_same_user

**Model:**
- 'is valid when question and survey have the same user'
- 'is not valid when question and survey have different user'


#### Only select the appropriate.
- [x] **Model testing.**
- [ ] **Request testing.**
- [ ] **System testing.**
- [ ] **No tests required.**


