### PR TITLE
Add OptionSerializer

### DIFF
--- a/backend/app/serializers/option_serializer.rb
+++ b/backend/app/serializers/option_serializer.rb
@@ -1,0 +1,3 @@
+class OptionSerializer < ActiveModel::Serializer
+  attributes :id, :name, :correct
+end

--- a/backend/app/serializers/question_serializer.rb
+++ b/backend/app/serializers/question_serializer.rb
@@ -1,5 +1,11 @@
 class QuestionSerializer < ActiveModel::Serializer
-  attributes :id, :name, :question_type
+  attributes :id, :name, :question_type, :options
+
+  def options
+    object.options.map do |option|
+      OptionSerializer.new(option)
+    end
+  end
 
   def question_type
     QuestionTypeSerializer.new(object.question_type)

--- a/backend/spec/requests/surveys_request_spec.rb
+++ b/backend/spec/requests/surveys_request_spec.rb
@@ -6,6 +6,7 @@ RSpec.describe 'SurveysController', type: :request do
     let!(:survey_question) { survey.questions.first }
     let!(:question_type) { survey_question.question_type }
     let!(:survey_subject) { survey.survey_subject }
+    let!(:option) { create(:option, question: survey_question) }
 
     before { get api_v1_survey_path(survey), headers: auth_headers }
 
@@ -23,7 +24,12 @@ RSpec.describe 'SurveysController', type: :request do
           'question_type' => {
             'id' => question_type.id,
             'name' => question_type.name
-          }
+          },
+          'options' => [{
+            'id' => option.id,
+            'name' => option.name,
+            'correct' => option.correct
+          }]
         ]
       }
       expect(response_body).to match(expected_attributes)


### PR DESCRIPTION
fix #258 

# Add OptionSerializer

**OptionSerializer:**
- Add name, Id and correct to attributes.

**QuestionSerializer:**
- Add options method to add all options to QuestionSerializer.

### Rspec

**SurveyRequests:**
- Add options to survey request test.


#### Only select the appropriate.
- [ ] **Model testing.**
- [x] **Request testing.**
- [ ] **System testing.**
- [ ] **No tests required.**


