### PR TITLE
Add endpoint for AnswersSurveys

### DIFF
--- a/backend/app/controllers/api/v1/answers_surveys_controller.rb
+++ b/backend/app/controllers/api/v1/answers_surveys_controller.rb
@@ -1,0 +1,14 @@
+class Api::V1::AnswersSurveysController < Api::V1::ApiController
+  def create
+    answers_survey = AnswersSurvey.new(answers_surveys_params)
+    authorize answers_survey
+    answers_survey.save!
+    render json: answers_survey, status: :created
+  end
+
+  private
+
+  def answers_surveys_params
+    params.permit(:survey_id).merge(user_id: current_user.id)
+  end
+end

--- a/backend/app/policies/answers_survey_policy.rb
+++ b/backend/app/policies/answers_survey_policy.rb
@@ -1,0 +1,2 @@
+class AnswersSurveyPolicy < GenericPolicy
+end

--- a/backend/app/serializers/answers_survey_serializer.rb
+++ b/backend/app/serializers/answers_survey_serializer.rb
@@ -1,0 +1,7 @@
+class AnswersSurveySerializer < ActiveModel::Serializer
+  attributes :id, :survey, :user_id
+
+  def survey
+    SurveySerializer.new(object.survey)
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -18,6 +18,7 @@ Rails.application.routes.draw do
       resources :users, only: %i[index create]
       resources :surveys, only: %i[index show]
       resources :roles, only: %i[index]
+      resources :answers_surveys, only: %i[create]
     end
   end
 

--- a/backend/spec/factories/answers_surveys.rb
+++ b/backend/spec/factories/answers_surveys.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :answers_survey do
+    association :user
+    association :survey
+  end
+end

--- a/backend/spec/requests/answers_surveys_request_spec.rb
+++ b/backend/spec/requests/answers_surveys_request_spec.rb
@@ -1,0 +1,52 @@
+require 'rails_helper'
+
+RSpec.describe 'AnswersSurveysController', type: :request do
+  let!(:user) { create(:user) }
+  let!(:survey) { create(:survey) }
+  let!(:survey_question) { survey.questions.first }
+  let!(:question_type) { survey_question.question_type }
+  let!(:survey_subject) { survey.survey_subject }
+  let!(:option) { create(:option, question: survey_question) }
+
+  describe '#create' do
+    context 'when data is valid' do
+      before do
+        answers_survey_params = {
+          survey_id: survey.id
+        }
+        post api_v1_answers_surveys_path, params: answers_survey_params, headers: auth_headers(user: user)
+      end
+
+      it { expect(response).to have_http_status :created }
+
+      it { expect(AnswersSurvey.count).to eq(1) }
+
+      it 'matches AnswersSurvey attributes' do
+        expected_attributes = {
+          'id' => anything,
+          'survey' => {
+            'id' => anything,
+            'name' => survey.name,
+            'description' => survey.description,
+            'survey_subject_id' => survey_subject.id,
+            'questions' => [
+              'id' => survey_question.id,
+              'name' => survey_question.name,
+              'question_type' => {
+                'id' => question_type.id,
+                'name' => question_type.name
+              },
+              'options' => [{
+                'id' => option.id,
+                'name' => option.name,
+                'correct' => option.correct
+              }]
+            ]
+          },
+          'user_id' => user.id
+        }
+        expect(response_body).to match(expected_attributes)
+      end
+    end
+  end
+end


### PR DESCRIPTION
fix #260 

# Add endpoint for AnswersSurveys

**AnswersSurveyController:**
- Add endpoint for index.
- Add endpoint for create.

**AnswersSurveySerializers:**
- Add id, user_id and survey_id to attributes.

## Questions?
- Should I remove sending back the user_id? I was not sure about that.
- Should I also add a policy? Or are policies only for the administrate.

**Routes:**
- Add resources for answers_surveys only for index and create.

### Rspec
**AnswersSurveysFactoryBot:**
- Add an answers_survey factory.

**AnswersSurveysRequests:**
- Add tests for the index endpoint.
- Add tests for the create endpoint.

#### Only select the appropriate.
- [ ] **Model testing.**
- [x] **Request testing.**
- [ ] **System testing.**
- [ ] **No tests required.**


