### PR TITLE
Only show all roles when admin in roles endpoint

### DIFF
--- a/backend/app/controllers/api/v1/roles_controller.rb
+++ b/backend/app/controllers/api/v1/roles_controller.rb
@@ -2,6 +2,6 @@ class Api::V1::RolesController < Api::V1::ApiController
   skip_before_action :authenticate_user!, only: [:index]
 
   def index
-    render json: Role.all
+    render json: Role.by_user(current_user)
   end
 end

--- a/backend/app/models/role.rb
+++ b/backend/app/models/role.rb
@@ -5,6 +5,12 @@ class Role < ApplicationRecord
 
   before_destroy :check_users_before_destroy, prepend: true
 
+  scope :by_user, lambda { |user|
+    return where.not(role_type: Role::ADMIN) unless user&.admin?
+
+    all
+  }
+
   ADMIN = 'admin'.freeze
   TEACHER = 'teacher'.freeze
   MODERATOR = 'moderator'.freeze

--- a/backend/spec/factories/roles.rb
+++ b/backend/spec/factories/roles.rb
@@ -20,5 +20,6 @@ FactoryBot.define do
 
   factory :role_student, parent: :role do
     role_type { Role::STUDENT }
+    initialize_with { Role.find_or_create_by(role_type: Role::STUDENT) }
   end
 end

--- a/backend/spec/models/role_spec.rb
+++ b/backend/spec/models/role_spec.rb
@@ -52,4 +52,23 @@ RSpec.describe Role, type: :model do
 
     it { expect(create(:role_moderator)).to eq(create(:role_moderator)) }
   end
+
+  describe '.by_role' do
+    let!(:role_moderator) { create(:role_moderator) }
+    let!(:role_teacher) { create(:role_teacher) }
+    let!(:role_student) { create(:role_student) }
+    let!(:role_admin) { create(:role_admin) }
+    let!(:not_admin_roles) { [role_moderator, role_teacher, role_student] }
+    let!(:all_roles) { [*not_admin_roles, role_admin] }
+    let!(:user_teacher) { create(:user_teacher) }
+    let(:user_admin) { create(:user) }
+
+    it 'shows all roles when admin' do
+      expect(described_class.by_user(user_admin)).to match(all_roles)
+    end
+
+    it 'shows all not admin roles' do
+      expect(described_class.by_user(user_teacher)).to match(not_admin_roles)
+    end
+  end
 end

--- a/backend/spec/requests/roles_request_spec.rb
+++ b/backend/spec/requests/roles_request_spec.rb
@@ -2,14 +2,40 @@ require 'rails_helper'
 
 RSpec.describe 'RolesController', type: :request do
   describe '#list' do
-    let!(:role) { create(:role) }
+    let!(:role_moderator) { create(:role_moderator) }
+    let!(:role_teacher) { create(:role_teacher) }
+    let!(:role_student) { create(:role_student) }
+    let!(:role_admin) { create(:role_admin) }
+    let!(:not_admin_roles) do
+      [{ 'id' => role_moderator.id, 'role_type' => role_moderator.role_type },
+       { 'id' => role_teacher.id, 'role_type' => role_teacher.role_type }, { 'id' => role_student.id, 'role_type' => role_student.role_type }]
+    end
+    let!(:all_roles) { [*not_admin_roles, { 'id' => role_admin.id, 'role_type' => role_admin.role_type }] }
 
-    before { get api_v1_roles_path }
+    let(:user_admin) { create(:user) }
 
-    it { expect(response).to have_http_status :ok }
+    describe 'when admin, list all roles' do
+      before do
+        get api_v1_roles_path, headers: auth_headers(user: user_admin)
+      end
 
-    it 'matches surveys attributes' do
-      expect(response_body).to match([{ 'id' => role.id, 'role_type' => role.role_type }])
+      it { expect(response).to have_http_status :ok }
+
+      it { expect(response_body).to match(all_roles) }
+    end
+
+    describe 'when user is not admin, list all not admin roles' do
+      before do
+        get api_v1_roles_path
+      end
+
+      it { expect(response).to have_http_status :ok }
+
+      it { expect(response_body).to match(not_admin_roles) }
+
+      it 'does not show admin role' do
+        expect(response_body).not_to include({ 'id' => role_admin.id, 'role_type' => role_admin.role_type })
+      end
     end
   end
 end

--- a/backend/spec/support/json_response_helper.rb
+++ b/backend/spec/support/json_response_helper.rb
@@ -1,11 +1,10 @@
 require 'devise/jwt/test_helpers'
 
 module JsonResponseHelper
-  def auth_headers(user: nil)
+  def auth_headers(user: create(:user))
     headers = {
       'Accept' => 'application/json'
     }
-    user ||= create(:user)
     Devise::JWT::TestHelpers.auth_headers(headers, user)
   end
 


### PR DESCRIPTION
fix #267 

# Add Filter On Roles Endpoint

**RolesController:**
- Render all roles when admin.
- Render all roles except the admin role when not logged in.

### Rspec
**RolesFactory:**
- Add Initialize with to the student factory.


**Requests:**
- Add tests to show all roles when logged in as admin.
- Add tests to show all roles except the admin role when not logged in.


#### Only select the appropriate.
- [ ] **Model testing.**
- [x] **Request testing.**
- [ ] **System testing.**
- [ ] **No tests required.**


