### PR TITLE
Add endpoint for create action for answers

### DIFF
--- a/backend/app/controllers/api/v1/answers_controller.rb
+++ b/backend/app/controllers/api/v1/answers_controller.rb
@@ -1,0 +1,16 @@
+class Api::V1::AnswersController < Api::V1::ApiController
+  include AnswerConcern
+
+  def create
+    answer = build_answer(answer_params)
+    authorize answer
+    answer.save!
+    render json: answer, status: :created
+  end
+
+  private
+
+  def answer_params
+    params.permit(:question_id, :answers_survey_id)
+  end
+end

--- a/backend/app/controllers/concerns/answer_concern.rb
+++ b/backend/app/controllers/concerns/answer_concern.rb
@@ -1,0 +1,11 @@
+module AnswerConcern
+  extend ActiveSupport::Concern
+
+  def build_answer(answer_params)
+    answer = Answer.new(answer_params)
+    params[:option_ids].each do |option|
+      answer.options << Option.find(option)
+    end
+    answer
+  end
+end

--- a/backend/app/models/answer.rb
+++ b/backend/app/models/answer.rb
@@ -1,5 +1,7 @@
 class Answer < ApplicationRecord
   belongs_to :question
-  belongs_to :option
   belongs_to :answers_survey
+
+  has_many :answers_options, dependent: :destroy
+  has_many :options, through: :answers_options
 end

--- a/backend/app/models/answers_option.rb
+++ b/backend/app/models/answers_option.rb
@@ -1,0 +1,4 @@
+class AnswersOption < ApplicationRecord
+  belongs_to :answer
+  belongs_to :option
+end

--- a/backend/app/models/option.rb
+++ b/backend/app/models/option.rb
@@ -2,7 +2,8 @@ class Option < ApplicationRecord
   belongs_to :user
   belongs_to :question
 
-  has_many :answers, dependent: :destroy
+  has_many :answers_options, dependent: :destroy
+  has_many :answers, through: :answers_options
 
   validates :name, presence: true, uniqueness: { scope: :question_id }
   validate :validates_correct

--- a/backend/app/policies/answer_policy.rb
+++ b/backend/app/policies/answer_policy.rb
@@ -1,0 +1,2 @@
+class AnswerPolicy < GenericPolicy
+end

--- a/backend/app/serializers/answer_serializer.rb
+++ b/backend/app/serializers/answer_serializer.rb
@@ -1,0 +1,9 @@
+class AnswerSerializer < ActiveModel::Serializer
+  attributes :id, :answers_survey_id, :question_id, :options
+
+  def options
+    object.options.map do |option|
+      OptionSerializer.new(option)
+    end
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -19,6 +19,7 @@ Rails.application.routes.draw do
       resources :surveys, only: %i[index show]
       resources :roles, only: %i[index]
       resources :answers_surveys, only: %i[create]
+      resources :answers, only: %i[create]
     end
   end
 

--- a/backend/db/migrate/20210625092530_create_answers_options.rb
+++ b/backend/db/migrate/20210625092530_create_answers_options.rb
@@ -1,0 +1,10 @@
+class CreateAnswersOptions < ActiveRecord::Migration[6.1]
+  def change
+    create_table :answers_options do |t|
+      t.references :answer, null: false, foreign_key: true
+      t.references :option, null: false, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/backend/db/schema.rb
+++ b/backend/db/schema.rb
@@ -10,20 +10,36 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2021_06_21_130819) do
+ActiveRecord::Schema.define(version: 2021_06_25_092530) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
+  create_table "answer_options", force: :cascade do |t|
+    t.bigint "option_id", null: false
+    t.bigint "answer_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["answer_id"], name: "index_answer_options_on_answer_id"
+    t.index ["option_id"], name: "index_answer_options_on_option_id"
+  end
+
   create_table "answers", force: :cascade do |t|
     t.bigint "question_id", null: false
-    t.bigint "option_id", null: false
     t.bigint "answers_survey_id", null: false
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
     t.index ["answers_survey_id"], name: "index_answers_on_answers_survey_id"
-    t.index ["option_id"], name: "index_answers_on_option_id"
     t.index ["question_id"], name: "index_answers_on_question_id"
+  end
+
+  create_table "answers_options", force: :cascade do |t|
+    t.bigint "answer_id", null: false
+    t.bigint "option_id", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.index ["answer_id"], name: "index_answers_options_on_answer_id"
+    t.index ["option_id"], name: "index_answers_options_on_option_id"
   end
 
   create_table "answers_surveys", force: :cascade do |t|
@@ -109,6 +125,10 @@ ActiveRecord::Schema.define(version: 2021_06_21_130819) do
     t.index ["role_id"], name: "index_users_on_role_id"
   end
 
+  add_foreign_key "answer_options", "answers"
+  add_foreign_key "answer_options", "options"
+  add_foreign_key "answers_options", "answers"
+  add_foreign_key "answers_options", "options"
   add_foreign_key "options", "questions"
   add_foreign_key "options", "users"
   add_foreign_key "surveys", "survey_subjects"

--- a/backend/spec/factories/answers.rb
+++ b/backend/spec/factories/answers.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :answer do
+    association  :answers_survey
+    association  :question
+    association  :option
+  end
+end

--- a/backend/spec/models/answer_spec.rb
+++ b/backend/spec/models/answer_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe Answer, type: :model do
   describe 'relationships' do
     it { is_expected.to belong_to(:question).required }
-    it { is_expected.to belong_to(:option).required }
     it { is_expected.to belong_to(:answers_survey).required }
+    it { is_expected.to have_many(:answers_options).dependent(:destroy) }
+    it { is_expected.to have_many(:options) }
   end
 end

--- a/backend/spec/models/answers_option_spec.rb
+++ b/backend/spec/models/answers_option_spec.rb
@@ -1,0 +1,8 @@
+require 'rails_helper'
+
+RSpec.describe AnswersOption, type: :model do
+  describe 'relationships' do
+    it { is_expected.to belong_to(:option).required }
+    it { is_expected.to belong_to(:answer).required }
+  end
+end

--- a/backend/spec/models/option_spec.rb
+++ b/backend/spec/models/option_spec.rb
@@ -19,7 +19,8 @@ RSpec.describe Option, type: :model do
   describe 'relationships' do
     it { is_expected.to belong_to(:user).required }
     it { is_expected.to belong_to(:question).required }
-    it { is_expected.to have_many(:answers).dependent(:destroy) }
+    it { is_expected.to have_many(:answers_options).dependent(:destroy) }
+    it { is_expected.to have_many(:answers) }
   end
 
   describe 'option validation' do

--- a/backend/spec/requests/answers_request_spec.rb
+++ b/backend/spec/requests/answers_request_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe 'AnswersController', type: :request do
+  describe '#create' do
+    context 'when data is valid' do
+      let(:survey) { create(:survey) }
+      let!(:answers_survey) { create(:answers_survey) }
+      let!(:question) { create(:question) }
+      let!(:option_a) { create(:option) }
+      let!(:option_b) { create(:option) }
+
+      before do
+        answer_params = {
+          question_id: question.id,
+          option_ids: [option_a.id, option_b.id],
+          answers_survey_id: answers_survey.id
+        }
+
+        post api_v1_answers_path, params: answer_params, headers: auth_headers
+      end
+
+      it { expect(response).to have_http_status :created }
+
+      it { expect(Answer.count).to eq(1) }
+
+      it { expect(Answer.first.options.count).to eq(2) }
+
+      it 'matches answer attributes' do
+        expected_attributes = {
+          'id' => anything,
+          'question_id' => question.id,
+          'options' => [{
+            'id' => option_a.id,
+            'name' => option_a.name,
+            'correct' => option_a.correct
+          },
+                        {
+                          'id' => option_b.id,
+                          'name' => option_b.name,
+                          'correct' => option_b.correct
+                        }],
+          'answers_survey_id' => answers_survey.id
+        }
+        expect(response_body).to match(expected_attributes)
+      end
+    end
+  end
+end


### PR DESCRIPTION
fix #261 

# Add Endpoint For Answers
**AnswersOptionModel:**
- Add belongs to option.
- Add belongs to answer.

**AnswerModel:**
- Remove option_id as we use a third model.
- Add has many AnswersOptions.
- Add has many options through AnswersOptions.

**OptionModel:**
- Add has many AnswersOptions.
- Add has many answers through AnswersOptions.

**AnswersController:**
- Add create method.
- Push all options in answer.options using Option.find.

**AnswerPolicies:**
- Use polymorphism by inheriting from GenericPolicy.

**AnswerSerializer:**
- Add all attributes plus options.
- Add option method that will make an array of all options.


### Rspec
**AnswersSurveyFactory:**
- Add association with user and survey.

**AnswersFactory:**
- Add association with answers_survey, question and option.

**AnswerModel:**
- Add tests for new relationship with third model.

**OptionModel:**
- Add tests for new relationship with third model.

**AnswersOptionModel:**
- Add tests to belongs to option and answer.

**AnswerRequest:**
- Add tests for create endpoint.
- Add test to see if only one answer was created with two options.

#### Only select the appropriate.
- [x] **Model testing.**
- [x] **Request testing.**
- [ ] **System testing.**
- [ ] **No tests required.**


