### PR TITLE
Add option validations for the Answer model

### DIFF
--- a/backend/app/controllers/concerns/answer_concern.rb
+++ b/backend/app/controllers/concerns/answer_concern.rb
@@ -3,8 +3,8 @@ module AnswerConcern
 
   def build_answer(answer_params, option_ids)
     answer = Answer.new(answer_params)
-    unless answer.free_text?
-      options = Option.includes(:user, :question).find(option_ids)
+    unless answer.free_text? || !option_ids
+      options = Option.includes(%i[user question]).find(option_ids)
       answer.options = options
     end
     answer

--- a/backend/app/models/answer.rb
+++ b/backend/app/models/answer.rb
@@ -7,6 +7,25 @@ class Answer < ApplicationRecord
 
   validates :user_answer, presence: true, if: :free_text?
   validates :question_id, presence: true, uniqueness: { scope: :answers_survey_id }
+  validate :minimum_one_option
+  validate :maximum_one_option
 
   delegate :free_text?, to: :question, allow_nil: true
+  delegate :single_choice?, to: :question, allow_nil: true
+
+  private
+
+  def minimum_one_option
+    return if free_text? || !options.empty?
+
+    # i18n-tasks-use t('activerecord.errors.models.answer.attributes.options.at_least_one_option')
+    errors.add(:options, :at_least_one_option)
+  end
+
+  def maximum_one_option
+    return unless single_choice? && options.length > 1
+
+    # i18n-tasks-use t('activerecord.errors.models.answer.attributes.question_id.only_one_option')
+    errors.add(:question_id, :only_one_option)
+  end
 end

--- a/backend/config/locales/en.yml
+++ b/backend/config/locales/en.yml
@@ -3,6 +3,12 @@ en:
   activerecord:
     errors:
       models:
+        answer:
+          attributes:
+            options:
+              at_least_one_option: Should have at least one option.
+            question_id:
+              only_one_option: Can't select more than one option when single choice.
         answers_survey:
           attributes:
             base:

--- a/backend/config/locales/pt-br.yml
+++ b/backend/config/locales/pt-br.yml
@@ -3,6 +3,12 @@ pt-br:
   activerecord:
     errors:
       models:
+        answer:
+          attributes:
+            options:
+              at_least_one_option: Deve ter pelo menos uma opção.
+            question_id:
+              only_one_option: Não é possível selecionar mais de uma opção em uma única escolha.
         answers_survey:
           attributes:
             base:

--- a/backend/spec/factories/answers.rb
+++ b/backend/spec/factories/answers.rb
@@ -7,4 +7,8 @@ FactoryBot.define do
   factory :free_text_answer, parent: :answer do
     question { create(:free_text_question) }
   end
+
+  factory :answer_with_option, parent: :answer do
+    options { [create(:option)] }
+  end
 end

--- a/backend/spec/factories/answers_surveys.rb
+++ b/backend/spec/factories/answers_surveys.rb
@@ -8,7 +8,7 @@ FactoryBot.define do
     survey { create(:survey_with_2_questions) }
 
     after(:create) do |answers_survey|
-      answers_survey.answers = create_list(:answer, 1, question: answers_survey.survey.questions[0])
+      answers_survey.answers = create_list(:answer_with_option, 1, question: answers_survey.survey.questions[0])
       answers_survey.save
     end
   end
@@ -17,8 +17,8 @@ FactoryBot.define do
     survey { create(:survey_with_2_questions) }
 
     after(:create) do |answers_survey|
-      answer1 = create(:answer, question: answers_survey.survey.questions[0])
-      answer2 = create(:answer, question: answers_survey.survey.questions[1])
+      answer1 = create(:answer_with_option, question: answers_survey.survey.questions[0])
+      answer2 = create(:answer_with_option, question: answers_survey.survey.questions[1])
       answers_survey.answers = [answer1, answer2]
       answers_survey.save
     end

--- a/backend/spec/models/answer_spec.rb
+++ b/backend/spec/models/answer_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
 RSpec.describe Answer, type: :model do
-  subject { create(:answer) }
+  subject { build(:answer) }
 
   describe 'relationships' do
     it { is_expected.to belong_to(:question).required }
@@ -23,6 +23,24 @@ RSpec.describe Answer, type: :model do
     it 'is valid when question has user_answer' do
       answer = build(:free_text_answer, options: [], user_answer: 'something')
       expect(answer).to be_valid
+    end
+  end
+
+  describe '#minimum_one_option' do
+    it do
+      answer = build(:answer)
+      answer.valid?
+      expect(answer.errors.full_messages).to include('Options Should have at least one option.')
+    end
+  end
+
+  describe '#maximum_one_option' do
+    it do
+      option1 = build(:option)
+      option2 = build(:option)
+      answer = build(:answer, options: [option1, option2])
+      answer.valid?
+      expect(answer.errors.full_messages).to include("Question Can't select more than one option when single choice")
     end
   end
 end

--- a/backend/spec/requests/answers_request_spec.rb
+++ b/backend/spec/requests/answers_request_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'AnswersController', type: :request do
       let!(:user_teacher) { create(:user_teacher) }
       let!(:user_student) { create(:user_student) }
       let!(:answers_survey) { create(:answers_survey, user: user_student) }
-      let!(:question) { create(:question, user: user_teacher) }
+      let!(:question) { create(:multiple_choice_question, user: user_teacher) }
       let!(:option_a) { create(:option, user: user_teacher) }
       let!(:option_b) { create(:option, user: user_teacher) }
 
@@ -78,6 +78,36 @@ RSpec.describe 'AnswersController', type: :request do
           }
           expect(response_body).to match(expected_attributes)
         end
+      end
+    end
+
+    context 'when data is not valid', bullet: :skip do
+      let!(:user_teacher) { create(:user_teacher) }
+      let!(:user_student) { create(:user_student) }
+      let!(:answers_survey) { create(:answers_survey, user: user_student) }
+      let!(:question) { create(:question, user: user_teacher) }
+      let!(:option_a) { create(:option, user: user_teacher) }
+      let!(:option_b) { create(:option, user: user_teacher) }
+      let(:option_ids) { [option_a.id, option_b.id] }
+
+      before do
+        answer_params = {
+          question_id: question.id,
+          option_ids: option_ids,
+          answers_survey_id: answers_survey.id
+        }
+
+        post api_v1_answers_path, params: answer_params, headers: auth_headers(user: user_student)
+      end
+
+      context 'when question is single choice and answer has more than one option' do
+        it { expect(response).to have_http_status :unprocessable_entity }
+      end
+
+      context 'when question is not free text and answer has no options' do
+        let(:option_ids) { nil }
+
+        it { expect(response).to have_http_status :unprocessable_entity }
       end
     end
   end

--- a/backend/spec/spec_helper.rb
+++ b/backend/spec/spec_helper.rb
@@ -17,6 +17,14 @@ RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
   # assertions if you prefer.
+  config.before(:each, bullet: :skip) do
+    Bullet.enable = false
+  end
+
+  config.after(:each, bullet: :skip) do
+    Bullet.enable = true
+  end
+
   config.expect_with :rspec do |expectations|
     # This option will default to `true` in RSpec 4. It makes the `description`
     # and `failure_message` of custom matchers include text for helper methods


### PR DESCRIPTION
# Validations When Creating Answer

### Answer model
The `#minimum_one_option` validation is needed for when
creating an answer without any options this should only be
available for `free_text` questions.

The `#maximum_one_option` validation is needed when creating
an answer for a `single_choice` question and selecting more than
one option.

### Factory
Add `answer_with_option` factory as all answers need an option now.

fix #278 

#### Only select the appropriate.
- [ ] **Model testing.**
- [ ] **Request testing.**
- [ ] **System testing.**
- [ ] **No tests required.**


