### PR TITLE
Fix database bug

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -14,5 +14,7 @@
 - `cd backend`
 - `bundle install`
 - `bundle exec rake db:create db:migrate db:seed`
-- `bundle exec rspec` (need environment variables from `docker-compose.yml`)
-- `bundle exec rails s -b 0` (need environment variables from `docker-compose.yml`)
+- `export RAILS_MASTER_KEY: 'a667717bf0a47475b0582547379c816d'`
+- `export DEVISE_JWT_SECRET_KEY: 'e26a21cfca4fdf67cc4e82385ba2d6ea4fb83ad1f8f5'`
+- `bundle exec rspec`
+- `bundle exec rails s -b 0`

--- a/backend/config/database.yml
+++ b/backend/config/database.yml
@@ -2,7 +2,7 @@ default: &default
   adapter: postgresql
   encoding: unicode
   pool: 5
-  <%if ENV["DOCKER_ENV"] %>
+  <%if ENV["DOCKER_ENV"] == 'true' %>
   database: <%= ENV.fetch("DATABASE_NAME") %>
   username: <%= ENV.fetch("DATABASE_USERNAME") %>
   password: <%= ENV.fetch("DATABASE_PASSWORD") %>


### PR DESCRIPTION
# Fix Database Bug

As the environment variables only contains strings,
we should compare it to the string `"true"` instead
of just checking if `ENV["DOCKER_ENV"]` is true, as
in ruby any string is true.

fix #319 



#### Only select the appropriate.
- [ ] **Model testing.**
- [ ] **Request testing.**
- [ ] **System testing.**
- [x] **No tests required.**


