### PR TITLE
Downgrade Nokogiri for Heroku

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -1,5 +1,5 @@
 source 'https://rubygems.org'
-git_source(:github) { |repo| 'https://github.com/#{repo}.git' }
+git_source(:github) { |_repo| 'https://github.com/#{repo}.git' }
 
 ruby '3.0.2'
 
@@ -21,7 +21,7 @@ gem 'turbolinks', '~> 5'
 gem 'jbuilder', '~> 2.7'
 # Use Active Model has_secure_password
 # gem 'bcrypt', '~> 3.1.7'
-
+gem 'nokogiri', '~> 1.12', '>= 1.12.4'
 # Reduces boot times through caching; required in config/boot.rb
 gem 'bootsnap', '>= 1.4.4', require: false
 
@@ -37,7 +37,7 @@ group :development, :test do
   # Call 'byebug' anywhere in the code to stop execution and get a debugger console
   gem 'bullet'
   gem 'factory_bot_rails'
-  gem 'faker', :git => 'https://github.com/faker-ruby/faker.git', :branch => 'master'
+  gem 'faker', git: 'https://github.com/faker-ruby/faker.git', branch: 'master'
   gem 'pry-rails'
   gem 'rspec-rails', '~> 4.0.2'
 end
@@ -59,7 +59,7 @@ end
 gem 'administrate'
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
-gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+gem 'tzinfo-data', platforms: %i[mingw mswin x64_mingw jruby]
 
 gem 'rubocop-performance', require: false
 gem 'rubocop-rails', require: false

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -463,6 +463,7 @@ DEPENDENCIES
   jbuilder (~> 2.7)
   jquery-rails
   listen (~> 3.3)
+  nokogiri (~> 1.12, >= 1.12.4)
   pg (~> 1.1)
   pry-rails
   puma (~> 5.0)


### PR DESCRIPTION
fix #323

# Fix Heroku Deploy

Heroku throws an error when using Nokogiri 1.12.5. For this, we downgraded Nokogiri to 1.12.4.


