### PR TITLE
Add better solution for spec helpers

### DIFF
--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -62,13 +62,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include JsonResponseHelper
 end
-
-require_relative 'support/shoulda_matchers'
-require_relative 'support/factory_bot'
-require_relative 'support/capybara'
-require_relative 'support/json_response_helper'
-
-# rubocop:disable Style/MixinUsage
-include JsonResponseHelper
-# rubocop:enable Style/MixinUsage


### PR DESCRIPTION
# Fix Spec Helper

As the spec helper already got a line for including all
the support files, we don't need to require them manually.

Solve rubocop error by simply including the module in the
RSpec config.

fix #325 



#### Only select the appropriate.
- [ ] **Model testing.**
- [ ] **Request testing.**
- [ ] **System testing.**
- [x] **No tests required.**


