### PR TITLE
fix broken login and register buttons

### DIFF
--- a/frontend/src/components/app-button/app-button.styles.ts
+++ b/frontend/src/components/app-button/app-button.styles.ts
@@ -9,15 +9,6 @@ export const StyledAppButton = styled(Button)`
   width: 100%;
   height: 36px;
   font-weight: normal;
-
-  @media (max-width: 500px) {
-    padding: 10px;
-    width: fit-content;
-    height: fit-content;
-    .text {
-      display: none;
-    }
-  }
 `;
 
 export const LoadingIcon = styled(MdSync)`


### PR DESCRIPTION
# fix broken login and register buttons

I was trying to resolve issues #308 and #186 when I caught up this discussion at PR #350 . I've found out that this media query was shriking the login and register buttons, so after asking a few people we thought that it is ok to remove it, so the reponsive layout can work properly.

