### PR TITLE
Fix login and register alignment

### DIFF
--- a/frontend/src/styles/login.styles.ts
+++ b/frontend/src/styles/login.styles.ts
@@ -66,7 +66,8 @@ export const LoginContainer = styled.div`
   display: flex;
   height: 100%;
   justify-content: center;
-  align-items: center;
+  align-items: start;
+  padding-top: 5vh;
   flex-direction: row;
 `;
 


### PR DESCRIPTION
Signed-off-by: Jay Clark <jay@jayeclark.dev>

fix #360 

# Fix login and register page alignment to be consistent
Basic CSS fix to align the top of the login and register forms while preserving the vertical centering on the page. (Register will be vertically centered, login will be very slightly above center but the logo and headline should appear in the same vertical position when swapping between the two pages.)

Neither form is responsive at smaller viewport heights so I may open an additional PR tomorrow to help improve that.

#### Only select the appropriate.

- [ ] **Model testing.**
- [ ] **Request testing.**
- [ ] **System testing.**
- [X] **No tests required.**
