### PR TITLE
Add translations for remaining hardcoded strings in the backend

### DIFF
--- a/backend/app/views/devise/registrations/new.slim
+++ b/backend/app/views/devise/registrations/new.slim
@@ -23,6 +23,6 @@
               =f.radio_button :role_id, student_role.id, id: 'inlineRadio2', class: 'form-check-input'
               label.form-check-label for="inlineRadio2"  Student
           .form-group.mb-3
-            = f.submit 'Sign up', class: 'btn btn-lg btn-info btn-block text-white'
-          = link_to "Log in", new_session_path(resource_name)
+            = f.submit t('devise.sessions.new.sign_up'), class: 'btn btn-lg btn-info btn-block text-white'
+          = link_to t('devise.sessions.new.sign_in'), new_session_path(resource_name)
     .col-lg-8.bg-cover.bg-image.d-none.d-lg-block

--- a/backend/app/views/devise/sessions/new.slim
+++ b/backend/app/views/devise/sessions/new.slim
@@ -18,6 +18,6 @@
               = f.label :password
               = f.password_field :password, autocomplete: 'current-password', class: 'form-control'
             .form-group.mb-3
-              = f.submit 'Log in', class: 'btn btn-primary'
-            = link_to "Sign up", new_registration_path(resource_name)
+              = f.submit t('devise.sessions.new.sign_in'), class: 'btn btn-primary'
+            = link_to t('devise.sessions.new.sign_up'), new_registration_path(resource_name)
     .col-lg-8.bg-cover.bg-image.d-none.d-lg-block

--- a/backend/app/views/surveys/index.slim
+++ b/backend/app/views/surveys/index.slim
@@ -10,5 +10,5 @@
               = survey.description
             = form_with url: answers_surveys_path, method: :post do |form|
               = form.hidden_field :survey_id, value: survey.id
-              = form.submit "Answer", class: 'btn btn-primary'
+              = form.submit t('surveys.answers.submit'), class: 'btn btn-primary'
 

--- a/backend/config/locales/en.yml
+++ b/backend/config/locales/en.yml
@@ -58,3 +58,7 @@ en:
     sessions:
       new:
         sign_in: Login
+        sign_up: Sign Up
+  surveys:
+    answers:
+      submit: Answer

--- a/backend/config/locales/pt-br.yml
+++ b/backend/config/locales/pt-br.yml
@@ -58,3 +58,7 @@ pt-br:
     sessions:
       new:
         sign_in: Login
+        sign_up: Inscrever-se
+  surveys:
+    answers:
+      submit: Responder

--- a/backend/spec/system/sign_in_spec.rb
+++ b/backend/spec/system/sign_in_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe 'User sign in', type: :system do
       fill_in 'Email', with: user.email
       fill_in 'Password', with: user.password
 
-      click_on 'Log in'
+      click_on 'Login'
     end
 
     it { expect(page).to have_current_path('/') }
@@ -30,7 +30,7 @@ RSpec.describe 'User sign in', type: :system do
       visit new_user_session_path
       fill_in 'Email', with: user_student.email
       fill_in 'Password', with: user_student.password
-      click_on 'Log in'
+      click_on 'Login'
     end
 
     it { expect(page).to have_current_path(surveys_path) }
@@ -42,7 +42,7 @@ RSpec.describe 'User sign in', type: :system do
       fill_in 'Email', with: user.email
       fill_in 'Password', with: 'invalid password'
 
-      click_on 'Log in'
+      click_on 'Login'
     end
 
     it { expect(page).to have_current_path(new_user_session_path) }


### PR DESCRIPTION
fix #347

# Add translations for remaining hardcoded strings in the backend

#### Only select the appropriate.

- [ ] **Model testing.**
- [ ] **Request testing.**
- [x] **System testing.**
- [ ] **No tests required.**
