### PR TITLE
✅ add case of test when api of survey return error #418

### DIFF
--- a/frontend/src/components/main/surveys-list.test.tsx
+++ b/frontend/src/components/main/surveys-list.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Survey } from 'api/models/survey';
 import { AnswerSurveyCreate } from 'api/models/answer_survey';
-import { fireEvent, render, waitFor } from 'test-utils';
+import { fireEvent, render, screen, waitFor } from 'test-utils';
 import { SurveysList } from './SurveysList';
 import { AxiosInstance } from 'axios';
 import { httpClient } from '../../api/client';
@@ -68,5 +68,24 @@ describe('Surveys list', () => {
         survey_id: 1,
       })
     );
+  });
+
+  it('not should show a survey when api return error', async () => {
+    const mockResponse = {
+      mock: true,
+    };
+
+    (httpClient as jest.Mocked<AxiosInstance>).post.mockImplementationOnce(
+      jest.fn((url: string, body: AnswerSurveyCreate) => {
+        return Promise.reject({ response: { data: mockResponse } });
+      })
+    );
+
+    await waitFor(() =>
+      expect(httpClient.post).toHaveBeenCalledWith('api/v1/answers_surveys', {
+        survey_id: 1,
+      })
+    );
+    expect(screen.queryByText('Animals survey')).toBeNull();
   });
 });

--- a/frontend/src/components/main/surveys-list.test.tsx
+++ b/frontend/src/components/main/surveys-list.test.tsx
@@ -70,7 +70,7 @@ describe('Surveys list', () => {
     );
   });
 
-  it('not should show a survey when api return error', async () => {
+  it('should not show a survey when api return error', async () => {
     const mockResponse = {
       mock: true,
     };


### PR DESCRIPTION
fix #418

#add case of test when api of survey return error

Test on error of api to register/start survey