### PR TITLE
Add Seeds service with public endpoint

### DIFF
--- a/backend/.reek.yml
+++ b/backend/.reek.yml
@@ -17,6 +17,16 @@ detectors:
   TooManyStatements:
     exclude:
       - "Users::SessionsController#create"
+      - "Seeds"
+  TooManyMethods:
+    exclude:
+      - "Seeds"
+  InstanceVariableAssumption:
+    exclude:
+      - "Seeds"
+  TooManyInstanceVariables:
+    exclude:
+      - "Seeds"
   # A lot of smells allow fine tuning their configuration. You can look up all available options
   # in the corresponding smell documentation in /docs. In most cases you probably can just go
   # with the defaults as documented in defaults.reek.yml.

--- a/backend/app/controllers/api/v1/api_controller.rb
+++ b/backend/app/controllers/api/v1/api_controller.rb
@@ -1,7 +1,7 @@
 class Api::V1::ApiController < ActionController::API
   include Pundit
 
-  before_action :authenticate_user!
+  before_action :authenticate_user!, except: :seed_database
 
   rescue_from Pundit::NotAuthorizedError, with: :render_unauthorized
   rescue_from ActiveRecord::RecordInvalid, with: :render_unprocessable_entity
@@ -12,5 +12,14 @@ class Api::V1::ApiController < ActionController::API
 
   def render_unprocessable_entity(exception)
     render json: { error_message: exception.message }, status: :unprocessable_entity
+  end
+
+  def seed_database
+    if Rails.env.production?
+      render json: { error_message: 'Oops not in production :(' }, status: :unauthorized
+    else
+      Seeds.call
+      render json: { message: 'uhu :)' }, status: :ok
+    end
   end
 end

--- a/backend/app/services/base.rb
+++ b/backend/app/services/base.rb
@@ -1,0 +1,11 @@
+class Base
+  def initialize; end
+
+  def self.call
+    new.call
+  end
+
+  def call
+    raise NotImplementedError
+  end
+end

--- a/backend/app/services/seeds.rb
+++ b/backend/app/services/seeds.rb
@@ -1,0 +1,207 @@
+class Seeds < Base
+  def call
+    clean_database
+    create_users
+    create_question_types
+    create_surveys
+    create_questions_and_options
+    create_answers
+    set_survey_ready
+  end
+
+  private
+
+  def clean_database
+    User.destroy_all
+    Role.destroy_all
+    QuestionType.destroy_all
+    Question.destroy_all
+    Survey.destroy_all
+    Option.destroy_all
+    SurveySubject.destroy_all
+    Answer.destroy_all
+  end
+
+  # Users and Roles
+
+  def create_roles
+    @role_admin = Role.create!(role_type: 'admin')
+    @role_teacher = Role.create!(role_type: 'teacher')
+    @role_student = Role.create!(role_type: 'student')
+  end
+
+  def create_users
+    create_roles
+    @user_admin = User.create!(email: 'admin@gmail.com', password: '123456', role: @role_admin)
+    @user_teacher = User.create!(email: 'teacher@gmail.com', password: '123456', role: @role_teacher)
+    @user_student = User.create!(email: 'student@gmail.com', password: '123456', role: @role_student)
+  end
+
+  # Questions, Question Types and Options
+
+  def create_question_types
+    @question_type_single_choice = QuestionType.create!(name: 'Single Choice')
+    @question_type_multiple_choice = QuestionType.create!(name: 'Multiple Choice')
+    @question_type_free_text = QuestionType.create!(name: 'Free Text')
+  end
+
+  def create_questions_and_options
+    options_for_question_one_admin
+    options_for_question_two_admin
+    options_for_question_one_teacher
+    option_incorrect_question_2_survey_teacher
+    options_for_question_one_color
+    options_for_question_two_color
+  end
+
+  def question_one_admin
+    @question_one_admin ||= Question.find_or_create_by!(
+      name: 'What is your favorit color?',
+      user: @user_admin,
+      survey: @survey_admin,
+      question_type: @question_type_single_choice
+    )
+  end
+
+  def options_for_question_one_admin
+    Option.create!(name: 'Red', question: question_one_admin, user: @user_admin)
+    Option.create!(name: 'Blue', question: question_one_admin, user: @user_admin)
+  end
+
+  def question_two_admin
+    @question_two_admin ||= Question.find_or_create_by!(
+      name: 'What is the RGB for color white?',
+      user: @user_admin,
+      survey: @survey_admin,
+      question_type: @question_type_single_choice
+    )
+  end
+
+  def options_for_question_two_admin
+    Option.create!(name: '255,255,255', question: question_two_admin, user: @user_admin)
+    Option.create!(name: '0,0,0', question: question_two_admin, user: @user_admin)
+  end
+
+  def question_one_teacher
+    @question_one_teacher ||= Question.find_or_create_by!(
+      name: 'What is your favorite animal?',
+      user: @user_teacher,
+      survey: @teacher_ready_survey,
+      question_type: @question_type_single_choice
+    )
+  end
+
+  def options_for_question_one_teacher
+    Option.create!(name: 'Dog', question: question_one_teacher, user: @user_teacher)
+    option_correct_question_1_survey_teacher
+    question_one_teacher.update!(ready_to_be_answered: true)
+  end
+
+  def question_two_teacher_ready
+    @question_two_teacher_ready ||= Question.find_or_create_by!(
+      name: 'What is the bigger animal?',
+      user: @user_teacher,
+      survey: @teacher_ready_survey,
+      question_type: @question_type_single_choice
+    )
+  end
+
+  def option_incorrect_question_2_survey_teacher
+    @option_incorrect_question_2_survey_teacher ||= Option.find_or_create_by!(
+      name: 'Horse',
+      question: question_two_teacher_ready,
+      correct: false,
+      user: @user_teacher
+    )
+    Option.create!(name: 'Cat', question: question_two_teacher_ready, correct: true, user: @user_teacher)
+    question_two_teacher_ready.update!(ready_to_be_answered: true)
+  end
+
+  def question_one_color_survey
+    @question_one_color_survey ||= Question.find_or_create_by!(
+      name: 'Translate blue',
+      user: @user_admin,
+      survey: @colors_survey_ready,
+      question_type: @question_type_single_choice
+    )
+  end
+
+  def options_for_question_one_color
+    Option.create!(name: 'branco', question: question_one_color_survey, correct: false, user: @user_admin)
+    correct_option_question_1_colors_survey
+    question_one_color_survey.update!(ready_to_be_answered: true)
+  end
+
+  def question_two_color_survey_ready
+    @question_two_color_survey_ready ||= Question.find_or_create_by!(
+      name: 'Translate red',
+      user: @user_admin,
+      survey: @colors_survey_ready,
+      question_type: @question_type_free_text
+    )
+  end
+
+  def options_for_question_two_color
+    Option.create!(name: 'vermelho', question: question_two_color_survey_ready, correct: true, user: @user_admin)
+    question_two_color_survey_ready.update!(ready_to_be_answered: true)
+  end
+
+  # correct options
+
+  def option_correct_question_1_survey_teacher
+    @option_correct_question_1_survey_teacher ||= Option.find_or_create_by!(
+      name: 'Eagle',
+      question: question_one_teacher,
+      correct: true,
+      user: @user_teacher
+    )
+  end
+
+  def correct_option_question_1_colors_survey
+    @correct_option_question_1_colors_survey ||= Option.find_or_create_by!(
+      name: 'azul',
+      question: question_one_color_survey,
+      correct: true,
+      user: @user_admin
+    )
+  end
+
+  # Surveys and Survey subject
+
+  def create_survey_subjects
+    @animal_subject = SurveySubject.create!(name: 'Animal', description: 'All the surveys contain questions related to animals.')
+    @color_subject = SurveySubject.create!(name: 'Color', description: 'All the surveys contain questions related to colors.')
+  end
+
+  def create_surveys
+    create_survey_subjects
+    animal_subject_id = @animal_subject.id
+    color_subject_id = @color_subject.id
+    @survey_admin = Survey.create!(name: 'Colors survey - Admin', user: @user_admin, survey_subject_id: color_subject_id)
+    @colors_survey_ready = Survey.create!(name: 'Colors survey - for Children', description: 'Favorite colors', user: @user_admin, survey_subject_id: color_subject_id)
+    @teacher_ready_survey = Survey.create!(name: 'Animals survey - Teacher', description: 'Nice animals', user: @user_teacher, survey_subject_id: animal_subject_id)
+    Survey.create!(name: 'Dog survey - Teacher', user: @user_teacher, survey_subject_id: animal_subject_id)
+    Survey.create!(name: 'Bunny survey - Teacher', user: @user_teacher, survey_subject_id: animal_subject_id)
+  end
+
+  def set_survey_ready
+    @teacher_ready_survey.update!(ready: true)
+    @colors_survey_ready.update!(ready: true)
+  end
+
+  # Answer Surveys and Answers
+
+  def answers_survey_colors
+    AnswersSurvey.find_or_create_by!(survey: @colors_survey_ready, user: @user_student)
+  end
+
+  def answers_survey_teacher
+    @answers_survey_teacher ||= AnswersSurvey.find_or_create_by!(survey: @teacher_ready_survey, user: @user_student)
+  end
+
+  def create_answers
+    Answer.create!(answers_survey: answers_survey_colors, question: question_one_color_survey, options: [correct_option_question_1_colors_survey])
+    Answer.create!(answers_survey: answers_survey_teacher, question: question_one_teacher, options: [option_correct_question_1_survey_teacher])
+    Answer.create!(answers_survey: answers_survey_teacher, question: question_two_teacher_ready, options: [@option_incorrect_question_2_survey_teacher])
+  end
+end

--- a/backend/config/routes.rb
+++ b/backend/config/routes.rb
@@ -29,6 +29,7 @@ Rails.application.routes.draw do
 
   get '/jwt_example', to: 'jwt_example#index'
   get '/', to: 'admin/users#index'
+  get '/api/v1/seed_database', to: 'api/v1/api#seed_database'
 
   devise_for :users, controllers: {
     sessions: 'users/sessions'

--- a/backend/spec/requests/api_controller_spec.rb
+++ b/backend/spec/requests/api_controller_spec.rb
@@ -1,0 +1,44 @@
+require 'rails_helper'
+
+RSpec.describe 'ApiController', type: :request do
+  describe '#seed_database' do
+    subject(:seed_call) { get '/api/v1/seed_database' }
+
+    before do
+      allow(Seeds).to receive(:call)
+    end
+
+    context 'when in production' do
+      before do
+        allow(Rails.env).to receive(:production?).and_return(true)
+        seed_call
+      end
+
+      it 'returns status unauthorized' do
+        expect(response).to have_http_status(:unauthorized)
+      end
+
+      it "returns a funny message saying 'Oops not in production'" do
+        expect(response_body).to include('error_message' => 'Oops not in production :(')
+      end
+    end
+
+    it 'calls the Seed service' do
+      seed_call
+
+      expect(Seeds).to have_received(:call)
+    end
+
+    it 'returns status ok' do
+      seed_call
+
+      expect(response).to have_http_status(:ok)
+    end
+
+    it 'returns a funny message saying uhu' do
+      seed_call
+
+      expect(response_body).to include('message' => 'uhu :)')
+    end
+  end
+end

--- a/backend/spec/routes_spec.rb
+++ b/backend/spec/routes_spec.rb
@@ -6,6 +6,6 @@ RSpec.describe 'Routes', type: :routing do
   end
 
   it 'has expected routes amount' do
-    expect(Rails.application.routes.routes.size).to eq(87)
+    expect(Rails.application.routes.routes.size).to eq(88)
   end
 end

--- a/backend/spec/services/base_spec.rb
+++ b/backend/spec/services/base_spec.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Base do
+  describe '#call' do
+    subject(:service) { described_class.new.call }
+
+    it 'raises a not implemented error' do
+      expect { service }.to raise_error(::NotImplementedError)
+    end
+  end
+end

--- a/backend/spec/services/seeds_spec.rb
+++ b/backend/spec/services/seeds_spec.rb
@@ -1,0 +1,29 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe Seeds do
+  describe '#call' do
+    before { described_class.call }
+
+    it 'creates 3 users' do
+      expect(User.count).to eq(3)
+    end
+
+    it 'creates 3 roles' do
+      expect(Role.count).to eq(3)
+    end
+
+    it 'creates 3 question types' do
+      expect(QuestionType.count).to eq(3)
+    end
+
+    it 'creates 2 survey subjects' do
+      expect(SurveySubject.count).to eq(2)
+    end
+
+    it 'creates 6 questions' do
+      expect(Question.count).to eq(6)
+    end
+  end
+end


### PR DESCRIPTION

fix #466 

# Public endpoint for reseeding the database

As we can't create 2 times the same answer it won't allow us to answer a survey twice.
Before we used to seed the database manually every time when all surveys got answered.

Now I've created a public endpoint that will do this for us.

In this way, we can refresh the database by simply calling an endpoint.


#### Only select the appropriate.

- [x] **Model testing.**
- [x] **Request testing.**
- [ ] **System testing.**
- [ ] **No tests required.**
