### PR TITLE
457 add missing internalization to views

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -33,3 +33,6 @@ coverage
 /vendor/*
 .bundle/config
 dockerfile_rails.tar
+
+.env.local
+.env.test

--- a/backend/app/controllers/questions_controller.rb
+++ b/backend/app/controllers/questions_controller.rb
@@ -7,6 +7,6 @@ class QuestionsController < ApplicationController
   private
 
   def translation_key(question)
-    question.question_type.name.downcase.split.join("_")
+    question.question_type.name.downcase.split.join('_')
   end
 end

--- a/backend/app/controllers/questions_controller.rb
+++ b/backend/app/controllers/questions_controller.rb
@@ -1,5 +1,12 @@
 class QuestionsController < ApplicationController
   def show
     @question = Question.find(params[:id])
+    @translation_key = translation_key(@question)
+  end
+
+  private
+
+  def translation_key(question)
+    question.question_type.name.downcase.split.join("_")
   end
 end

--- a/backend/app/controllers/surveys_controller.rb
+++ b/backend/app/controllers/surveys_controller.rb
@@ -6,7 +6,7 @@ class SurveysController < ApplicationController
   private
 
   def survey_presenters
-    Survey.ready_surveys.decorate.map do |survey|
+    Survey.ready_surveys.includes(questions: %i[question_type]).decorate.map do |survey|
       SurveyPresenter.payload(survey, current_user)
     end
   end

--- a/backend/app/presenters/answers_survey_presenter.rb
+++ b/backend/app/presenters/answers_survey_presenter.rb
@@ -24,7 +24,7 @@ class AnswersSurveyPresenter < BasePresenter
   protected
 
   def questions
-    @answers_survey.survey.questions.map do |question|
+    @answers_survey.survey.questions.includes([:question_type]).map do |question|
       QuestionPresenter.new(question).payload
     end
   end

--- a/backend/app/presenters/answers_survey_presenter.rb
+++ b/backend/app/presenters/answers_survey_presenter.rb
@@ -30,7 +30,7 @@ class AnswersSurveyPresenter < BasePresenter
   end
 
   def answered_questions
-    Question.answered_by_answers_survey(@answers_survey).map do |question|
+    Question.answered_by_answers_survey(@answers_survey).includes(%i[question_type options]).map do |question|
       QuestionPresenter.new(question).payload
     end
   end

--- a/backend/app/views/questions/show.slim
+++ b/backend/app/views/questions/show.slim
@@ -1,6 +1,8 @@
 h1 = @question.name
-h5 = "This is a #{@question.question_type.name.downcase} question."
+
+h5 = t("questions.show.#{@translation_key}")
+
 ul
   - @question.options.each do |option|
     li = option.name
-button Next
+button = t('questions.show.button')

--- a/backend/app/views/surveys/index.slim
+++ b/backend/app/views/surveys/index.slim
@@ -9,7 +9,7 @@
             p.card-text
               = survey[:description]
             p.card-text
-              = pluralize(survey[:answered_questions_quantity], 'question')
+              =  t('surveys.index.question', count: survey[:answered_questions_quantity])
               |  answered.
             = form_with url: answers_surveys_path, method: :post do |form|
               = form.hidden_field :survey_id, value: survey[:id]

--- a/backend/config/locales/en.yml
+++ b/backend/config/locales/en.yml
@@ -59,6 +59,16 @@ en:
       new:
         sign_in: Login
         sign_up: Sign Up
+  questions:
+    show:
+      button: Next
+      free_text: Free text question
+      multiple_choice: Multiple choice question
+      single_choice: Single choice question
   surveys:
     answers:
       submit: Answer
+    index:
+      question:
+        one: "%{count} question"
+        other: "%{count} questions"

--- a/backend/config/locales/pt-br.yml
+++ b/backend/config/locales/pt-br.yml
@@ -59,6 +59,16 @@ pt-br:
       new:
         sign_in: Login
         sign_up: Inscrever-se
+  questions:
+    show:
+      button: Próximo
+      free_text: Questão de texto livre
+      multiple_choice: Questão de múltipla escolha
+      single_choice: Questão de escolha única
   surveys:
     answers:
       submit: Responder
+    index:
+      question:
+        one: "%{count} questão"
+        other: "%{count} questões"

--- a/backend/spec/factories/questions.rb
+++ b/backend/spec/factories/questions.rb
@@ -32,6 +32,8 @@ FactoryBot.define do
   factory :question_with_answer, parent: :question do
     after(:create) do |question|
       create(:answer_with_option, question: question)
+      create(:correct_option, question: question)
+      question.ready_to_be_answered = true
       question.save!
     end
   end

--- a/backend/spec/factories/surveys.rb
+++ b/backend/spec/factories/surveys.rb
@@ -56,4 +56,11 @@ FactoryBot.define do
       survey.save!
     end
   end
+
+  factory :survey_with_two_answers, parent: :ready_survey do
+    after(:create) do |survey|
+      answersurvey = create(:answers_survey, survey: survey, user: survey.user)
+      create_list(:answer_with_option, 2, answers_survey: answersurvey)
+    end
+  end
 end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -64,15 +64,4 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include JsonResponseHelper
   config.include Devise::Test::IntegrationHelpers
-
-  # These two blocks check for scenarios with bullet: :skip, and if they find
-  # one before they run tests, they will set Bullet.enable to false and then
-  # set it back to true after.
-  config.before(:each, bullet: :skip) do
-    Bullet.enable = false
-  end
-
-  config.after(:each, bullet: :skip) do
-    Bullet.enable = true
-  end
 end

--- a/backend/spec/rails_helper.rb
+++ b/backend/spec/rails_helper.rb
@@ -64,4 +64,15 @@ RSpec.configure do |config|
   # config.filter_gems_from_backtrace("gem name")
   config.include JsonResponseHelper
   config.include Devise::Test::IntegrationHelpers
+
+  # These two blocks check for scenarios with bullet: :skip, and if they find
+  # one before they run tests, they will set Bullet.enable to false and then
+  # set it back to true after.
+  config.before(:each, bullet: :skip) do
+    Bullet.enable = false
+  end
+
+  config.after(:each, bullet: :skip) do
+    Bullet.enable = true
+  end
 end

--- a/backend/spec/system/front_end/question_views_spec.rb
+++ b/backend/spec/system/front_end/question_views_spec.rb
@@ -20,17 +20,17 @@ RSpec.describe 'Question', type: :system do
       end
     end
 
-    context 'single question type' do
+    context 'when single question type' do
       let(:question) { create(:single_choice_question) }
 
       it { expect(page).to have_content 'Single choice question' }
     end
 
-    context 'multiple question type' do
+    context 'when multiple question type' do
       it { expect(page).to have_content 'Multiple choice question' }
     end
 
-    context 'free text question type' do
+    context 'when free text question type' do
       let(:question) { create(:free_text_question) }
 
       it { expect(page).to have_content 'Free text question' }

--- a/backend/spec/system/front_end/question_views_spec.rb
+++ b/backend/spec/system/front_end/question_views_spec.rb
@@ -20,8 +20,20 @@ RSpec.describe 'Question', type: :system do
       end
     end
 
-    it 'displays the question type of the question' do
-      expect(page).to have_content 'This is a multiple choice question.'
+    context 'single question type' do
+      let(:question) { create(:single_choice_question) }
+
+      it { expect(page).to have_content 'Single choice question' }
+    end
+
+    context 'multiple question type' do
+      it { expect(page).to have_content 'Multiple choice question' }
+    end
+
+    context 'free text question type' do
+      let(:question) { create(:free_text_question) }
+
+      it { expect(page).to have_content 'Free text question' }
     end
   end
 end

--- a/backend/spec/system/front_end/survey_crud_spec.rb
+++ b/backend/spec/system/front_end/survey_crud_spec.rb
@@ -4,7 +4,6 @@ RSpec.describe 'Survey CRUD', type: :system do
   describe 'CRUD' do
     let!(:user_student) { create(:user_student) }
     let!(:survey) { create(:survey_with_answer, user: user_student) }
-    let!(:answers_survey) { survey.answers_surveys.last }
 
     describe '#index' do
       before do
@@ -18,14 +17,13 @@ RSpec.describe 'Survey CRUD', type: :system do
         it { expect(page).to have_text('1 question answered') }
       end
 
-      context 'with multiple questions' do
+      context 'with multiple answered questions' do
         before do
-          answers_survey.answers << create_list(:answer_with_option, 2)
-          survey.reload
+          create(:survey_with_two_answers, user: user_student)
           visit surveys_path
         end
 
-        it { expect(page).to have_text('3 questions answered') }
+        it { expect(page).to have_text('2 questions answered') }
       end
     end
   end

--- a/backend/spec/system/front_end/survey_crud_spec.rb
+++ b/backend/spec/system/front_end/survey_crud_spec.rb
@@ -4,6 +4,7 @@ RSpec.describe 'Survey CRUD', type: :system do
   describe 'CRUD' do
     let!(:user_student) { create(:user_student) }
     let!(:survey) { create(:survey_with_answer, user: user_student) }
+    let!(:answers_survey) { survey.answers_surveys.last }
 
     describe '#index' do
       before do
@@ -13,7 +14,19 @@ RSpec.describe 'Survey CRUD', type: :system do
 
       it { expect(page).to have_text(survey.name) }
 
-      it { expect(page).to have_text('1 question answered') }
+      context 'with one question' do
+        it { expect(page).to have_text('1 question answered') }
+      end
+
+      context 'with multiple questions' do
+        before do
+          answers_survey.answers << create_list(:answer_with_option, 2)
+          survey.reload
+          visit surveys_path
+        end
+
+        it { expect(page).to have_text('3 questions answered') }
+      end
     end
   end
 end


### PR DESCRIPTION
fix #457

# Add missing internationalization to views

### Yml files
- Translation strings are added to `en.yml` and `pt-br.yml` files, to be used in the views, helping a string to be translated in different languages. 

### Views:
**Questions #show** 

- In order a question type text to be translated a `translate method #t` is used. 
- Implement `if elsif else` statement condition, in order a different translation string from the `yml` files to be displayed. The content of the string that will be displayed depends on a `question_type`.
- `Translate method #t` and `translation string` from the yml are implemented also to translate the text content of the `Next button`

**Survey #index** 
- In order to translate **the number of answered questions** in singular and plural, the provided pluralization method and `translate method #t`  from `I18n gem` are used. As first parameter in the method a translate string from the `yml` file is passed. To the second parameter `count:`, `survey[:answered_questions_quantity]` is passed .

#### Only select the appropriate.

- [x] **View testing.**
- [ ] **Request testing.**
- [ ] **System testing.**
- [ ] **No tests required.**
