### PR TITLE
Add AnsweredQuestion to swagger doc schema

### DIFF
--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -32,6 +32,29 @@ components:
           items:
             $ref: '#/components/schemas/Question'
 
+    AnsweredQuestion:
+      type: object
+      properties:
+        id:
+          type: number
+        name:
+          type: string
+        question_type:
+          type: object
+          properties:
+            id:
+              type: integer
+            name:
+              type: string
+        options:
+          type: array
+          items:
+            $ref: '#/components/schemas/Option'
+        answered_options:
+              type: array
+              items:
+              $ref: '#/components/schemas/Option'
+
     AnswersSurveyWithAnswers:
       type: object
       properties:
@@ -44,7 +67,7 @@ components:
         questions:
           type: array
           items:
-            $ref: '#/components/schemas/Question'
+            $ref: '#/components/schemas/AnsweredQuestion'
         answered_questions:
           type: array
           items:
@@ -79,6 +102,13 @@ components:
           type: number
         name:
           type: string
+        question_type:
+          type: object
+          properties:
+            id:
+              type: integer
+            name:
+              type: string
         options:
           type: array
           items:


### PR DESCRIPTION
fix #485

# Add AnsweredQuestion to swagger doc schema

- Update the swagger documentation for `answers_surveys/{id}` `GET` method, in order `answered_options` filed  to be executed. 
- Add  missing `question_type` property to `Question schema`.
#### Only select the appropriate.

- [ ] **Model testing.**
- [ ] **Request testing and swagger doc update.**
- [ ] **System testing.**
- [ ] **No tests required.**
