### PR TITLE
Add QuestionType schema to the swagger doc 

### DIFF
--- a/backend/swagger/v1/swagger.yaml
+++ b/backend/swagger/v1/swagger.yaml
@@ -40,12 +40,7 @@ components:
         name:
           type: string
         question_type:
-          type: object
-          properties:
-            id:
-              type: integer
-            name:
-              type: string
+          $ref: '#/components/schemas/QuestionType'
         options:
           type: array
           items:
@@ -95,6 +90,14 @@ components:
           type: string
         correct:
           type: boolean
+    QuestionType:
+      type: object
+      properties:
+        id:
+          type: integer
+        name:
+          type: string
+
     Question:
       type: object
       properties:
@@ -103,12 +106,7 @@ components:
         name:
           type: string
         question_type:
-          type: object
-          properties:
-            id:
-              type: integer
-            name:
-              type: string
+            $ref: '#/components/schemas/QuestionType'
         options:
           type: array
           items:


### PR DESCRIPTION
fix #490

# Add QuestionType schema to the swagger doc
 
- `question_type` is used twice along the swagger file. To avoid duplication, `QuestionType schema` is created. 

#### Only select the appropriate.

- [ ] **Model testing.**
- [ ] **Request testing and swagger doc update.**
- [ ] **System testing.**
- [ ] **No tests required.**
