### PR TITLE
Refactor HashHelper

### DIFF
--- a/backend/.reek.yml
+++ b/backend/.reek.yml
@@ -1,5 +1,4 @@
 ---
-
 ### Generic smell configuration
 
 detectors:
@@ -81,4 +80,3 @@ exclude_paths:
   - bin/
   - vendor/
   - db/migrate
-  - spec/support/hash_helper.rb

--- a/backend/.rubocop.yml
+++ b/backend/.rubocop.yml
@@ -6,18 +6,17 @@ require:
 AllCops:
   NewCops: enable
   Include:
-    - '**/*.rb'
-    - '**/Rakefile'
-    - '**/config.ru'
+    - "**/*.rb"
+    - "**/Rakefile"
+    - "**/config.ru"
   Exclude:
-    - 'db/**/*'
-    - 'config/**/*'
-    - 'script/**/*'
-    - 'bin/**/*'
-    - 'log/**/*'
-    - 'vendor/**/*'
-    - 'node_modules/**/*'
-    - 'spec/support/hash_helper.rb'
+    - "db/**/*"
+    - "config/**/*"
+    - "script/**/*"
+    - "bin/**/*"
+    - "log/**/*"
+    - "vendor/**/*"
+    - "node_modules/**/*"
   TargetRubyVersion: 2.6.2
 
 Layout/LineLength:
@@ -30,15 +29,15 @@ Metrics/AbcSize:
   Max: 80
 
 Metrics/BlockLength:
-  IgnoredMethods: ['describe', 'context', 'it']
+  IgnoredMethods: ["describe", "context", "it"]
   Max: 35
   Exclude:
-    - 'spec/factories/*'
+    - "spec/factories/*"
 
 Metrics/ClassLength:
   Max: 200
   Exclude:
-    - 'app/services/seeds.rb'
+    - "app/services/seeds.rb"
 
 Metrics/CyclomaticComplexity:
   Max: 15

--- a/backend/spec/support/hash_helper.rb
+++ b/backend/spec/support/hash_helper.rb
@@ -5,6 +5,7 @@ module HashHelper
     end
   end
 
+  # :reek:TooManyStatements
   def answers_survey_sym(answers_survey)
     survey = answers_survey.survey
     survey_questions = survey.questions
@@ -25,10 +26,11 @@ module HashHelper
       unanswered_question_attributes
     ]
 
-    asnwers_survey_returned_params({ answers_survey: answers_survey, question_attributes: question_attributes, answered_question_attributes: answered_question_attributes,
+    answers_survey_returned_params({ answers_survey: answers_survey, question_attributes: question_attributes, answered_question_attributes: answered_question_attributes,
                                      unanswered_question_attributes: unanswered_question_attributes }).transform_keys(&:to_sym)
   end
 
+  # :reek:TooManyStatements
   def answers_survey_hash(answers_survey)
     survey = answers_survey.survey
     survey_questions = survey.questions
@@ -49,7 +51,7 @@ module HashHelper
       unanswered_question_attributes
     ]
 
-    asnwers_survey_returned_params({ answers_survey: answers_survey, question_attributes: question_attributes, answered_question_attributes: answered_question_attributes,
+    answers_survey_returned_params({ answers_survey: answers_survey, question_attributes: question_attributes, answered_question_attributes: answered_question_attributes,
                                      unanswered_question_attributes: unanswered_question_attributes })
   end
 
@@ -57,20 +59,19 @@ module HashHelper
     survey = answers_survey.survey
     survey_question = survey.questions.first
     survey_question_options = survey_question.options
-    option = survey_question_options.first
     option_three = survey_question_options.second
-    question_type = survey_question.question_type
 
     {
       'id' => survey_question.id,
       'name' => survey_question.name,
-      'question_type' => question_type(question_type),
-      'options' => options_hash([option, option_three]),
+      'question_type' => question_type(survey_question.question_type),
+      'options' => options_hash([survey_question_options.first, option_three]),
       'answered_options' => options_hash([option_three]),
       'correct' => false
     }
   end
 
+  # :reek:TooManyStatements
   def answers_survey_with_questions_hash(answers_survey)
     survey = answers_survey.survey
     survey_questions = survey.questions
@@ -95,7 +96,7 @@ module HashHelper
       unanswered_question_attributes
     ]
 
-    asnwers_survey_returned_params({ answers_survey: answers_survey, question_attributes: question_attributes, answered_question_attributes: answered_question_attributes,
+    answers_survey_returned_params({ answers_survey: answers_survey, question_attributes: question_attributes, answered_question_attributes: answered_question_attributes,
                                      unanswered_question_attributes: unanswered_question_attributes })
   end
 

--- a/backend/spec/support/hash_helper.rb
+++ b/backend/spec/support/hash_helper.rb
@@ -1,216 +1,121 @@
 module HashHelper
+  def self.included(base)
+    base.class_eval do
+      include HashHelperMethods
+    end
+  end
+
   def answers_survey_sym(answers_survey)
     survey = answers_survey.survey
-    survey_question = survey.questions.first
-    survey_question2 = survey.questions.second
-    option = survey_question.options.first
-    option3 = survey_question.options.second
-    option2 = survey_question2.options.first
+    survey_questions = survey.questions
+    survey_question = survey_questions.first
+    survey_question_two = survey_questions.second
+    survey_question_options = survey_question.options
+    option = survey_question_options.first
+    option_three = survey_question_options.second
+    option_two = survey_question_two.options.first
     question_type = survey_question.question_type
-    answered_question_attributes = {
-      'id' => survey_question.id,
-      'name' => survey_question.name,
-      'question_type' => {
-        'id' => question_type.id,
-        'name' => question_type.name
-      }.transform_keys(&:to_sym),
-      'options' => [{
-        'id' => option.id,
-        'name' => option.name,
-        'correct' => option.correct
-      }.transform_keys(&:to_sym),
-                    {
-                      'id' => option3.id,
-                      'name' => option3.name,
-                      'correct' => option3.correct
-                    }.transform_keys(&:to_sym)]
-    }.transform_keys(&:to_sym)
-    unanswered_question_attributes = {
-      'id' => survey_question2.id,
-      'name' => survey_question2.name,
-      'question_type' => {
-        'id' => question_type.id,
-        'name' => question_type.name
-      }.transform_keys(&:to_sym),
-      'options' => [{
-        'id' => option2.id,
-        'name' => option2.name,
-        'correct' => option2.correct
-      }.transform_keys(&:to_sym)]
-    }.transform_keys(&:to_sym)
+
+    answered_question_attributes = answers_survey_questions_attributes_sym(survey_question, question_type, [option, option_three])
+
+    unanswered_question_attributes = answers_survey_questions_attributes_sym(survey_question_two, question_type, [option_two])
 
     question_attributes = [
       answered_question_attributes,
       unanswered_question_attributes
     ]
 
-    {
-      id: answers_survey.id,
-      user_id: answers_survey.user_id,
-      status: answers_survey.status,
-      questions: question_attributes,
-      answered_questions: [answered_question_attributes],
-      not_answered_questions: [unanswered_question_attributes],
-      current_question_index: 1
-    }.transform_keys(&:to_sym)
+    asnwers_survey_returned_params({ answers_survey: answers_survey, question_attributes: question_attributes, answered_question_attributes: answered_question_attributes,
+                                     unanswered_question_attributes: unanswered_question_attributes }).transform_keys(&:to_sym)
   end
 
   def answers_survey_hash(answers_survey)
     survey = answers_survey.survey
-    survey_question = survey.questions.first
-    survey_question2 = survey.questions.second
-    option = survey_question.options.first
-    option3 = survey_question.options.second
-    option2 = survey_question2.options.first
+    survey_questions = survey.questions
+    survey_question = survey_questions.first
+    survey_question_two = survey_questions.second
+    survey_question_options = survey_question.options
+    option = survey_question_options.first
+    option_three = survey_question_options.second
+    option_two = survey_question_two.options.first
     question_type = survey_question.question_type
-    answered_question_attributes = {
-      'id' => survey_question.id,
-      'name' => survey_question.name,
-      'question_type' => {
-        'id' => question_type.id,
-        'name' => question_type.name
-      },
-      'options' => [{
-        'id' => option.id,
-        'name' => option.name,
-        'correct' => option.correct
-      },
-                    {
-                      'id' => option3.id,
-                      'name' => option3.name,
-                      'correct' => option3.correct
-                    }]
-    }
-    unanswered_question_attributes = {
-      'id' => survey_question2.id,
-      'name' => survey_question2.name,
-      'question_type' => {
-        'id' => question_type.id,
-        'name' => question_type.name
-      },
-      'options' => [{
-        'id' => option2.id,
-        'name' => option2.name,
-        'correct' => option2.correct
-      }]
-    }
+
+    answered_question_attributes = answers_survey_questions_attributes_hash(survey_question, question_type, [option, option_three])
+
+    unanswered_question_attributes = answers_survey_questions_attributes_hash(survey_question_two, question_type, [option_two])
 
     question_attributes = [
       answered_question_attributes,
       unanswered_question_attributes
     ]
 
-    {
-      'id' => answers_survey.id,
-      'user_id' => answers_survey.user_id,
-      'status' => answers_survey.status,
-      'questions' => question_attributes,
-      'answered_questions' => [answered_question_attributes],
-      'not_answered_questions' => [unanswered_question_attributes],
-      'current_question_index' => 1
-    }
+    asnwers_survey_returned_params({ answers_survey: answers_survey, question_attributes: question_attributes, answered_question_attributes: answered_question_attributes,
+                                     unanswered_question_attributes: unanswered_question_attributes })
   end
 
   def answered_question_hash(answers_survey)
     survey = answers_survey.survey
     survey_question = survey.questions.first
-    option = survey_question.options.first
-    option3 = survey_question.options.second
+    survey_question_options = survey_question.options
+    option = survey_question_options.first
+    option_three = survey_question_options.second
     question_type = survey_question.question_type
+
     {
       'id' => survey_question.id,
       'name' => survey_question.name,
-      'question_type' => {
-        'id' => question_type.id,
-        'name' => question_type.name
-      },
-      'options' => [{
-        'id' => option.id,
-        'name' => option.name,
-        'correct' => option.correct
-      }, {
-        'id' => option3.id,
-        'name' => option3.name,
-        'correct' => option3.correct
-      }],
-      'answered_options' => [{
-        'id' => option3.id,
-        'name' => option3.name,
-        'correct' => option3.correct
-      }],
+      'question_type' => question_type(question_type),
+      'options' => options_hash([option, option_three]),
+      'answered_options' => options_hash([option_three]),
       'correct' => false
     }
   end
 
   def answers_survey_with_questions_hash(answers_survey)
     survey = answers_survey.survey
-    survey_question = survey.questions.first
-    survey_question2 = survey.questions.second
-    option2 = survey_question2.options.first
+    survey_questions = survey.questions
+    survey_question = survey_questions.first
+    survey_question_two = survey_questions.second
+    option_two = survey_question_two.options.first
     question_type = survey_question.question_type
+
     answered_question_attributes = answered_question_hash(answers_survey)
 
     unanswered_question_attributes = {
-      'id' => survey_question2.id,
-      'name' => survey_question2.name,
-      'question_type' => {
-        'id' => question_type.id,
-        'name' => question_type.name
-      },
-      'options' => [{
-        'id' => option2.id,
-        'name' => option2.name,
-        'correct' => option2.correct
-      }],
+      'id' => survey_question_two.id,
+      'name' => survey_question_two.name,
+      'question_type' => question_type(question_type),
+      'options' => options_hash([option_two]),
       'answered_options' => [],
       'correct' => false
     }
 
-    questions_attributes = [
+    question_attributes = [
       answered_question_attributes,
       unanswered_question_attributes
     ]
 
-    {
-      'id' => answers_survey.id,
-      'user_id' => answers_survey.user.id,
-      'status' => answers_survey.status,
-      'questions' => questions_attributes,
-      'answered_questions' => [answered_question_attributes],
-      'not_answered_questions' => [unanswered_question_attributes],
-      'current_question_index' => 1
-    }
+    asnwers_survey_returned_params({ answers_survey: answers_survey, question_attributes: question_attributes, answered_question_attributes: answered_question_attributes,
+                                     unanswered_question_attributes: unanswered_question_attributes })
   end
 
-  def survey_hash(survey, answers_survey)
+  def survey_hash(_survey, answers_survey)
     answers_survey_attributes = answers_survey_hash(answers_survey)
 
     {
-      'id' => survey.id,
-      'name' => survey.name,
-      'description' => survey.description,
-      'survey_subject_id' => survey.survey_subject.id,
-      'answered_questions_quantity' => 1,
-      'total_questions_quantity' => 2,
       'questions' => answers_survey_attributes['questions'],
       'answers_surveys' => [answers_survey_attributes],
       'current_answers_survey' => answers_survey_attributes
-    }
+    }.merge(survey_helper.transform_keys(&:to_s))
   end
 
-  def survey_sym(survey, answers_survey)
+  def survey_sym(_survey, answers_survey)
     answers_survey_attributes = answers_survey_sym(answers_survey)
 
     {
-      id: survey.id,
-      name: survey.name,
-      description: survey.description,
-      survey_subject_id: survey.survey_subject.id,
-      answered_questions_quantity: 1,
-      total_questions_quantity: 2,
       questions: answers_survey_attributes[:questions],
       answers_surveys: [answers_survey_attributes],
       current_answers_survey: answers_survey_attributes
-    }
+    }.merge(survey_helper)
   end
 end

--- a/backend/spec/support/hash_helper_methods.rb
+++ b/backend/spec/support/hash_helper_methods.rb
@@ -46,7 +46,7 @@ module HashHelperMethods
     }
   end
 
-  def asnwers_survey_returned_params(params = {})
+  def answers_survey_returned_params(params = {})
     answers_survey = params[:answers_survey]
 
     {

--- a/backend/spec/support/hash_helper_methods.rb
+++ b/backend/spec/support/hash_helper_methods.rb
@@ -1,0 +1,73 @@
+module HashHelperMethods
+  module_function
+
+  def question_type(question_type)
+    {
+      'id' => question_type.id,
+      'name' => question_type.name
+    }
+  end
+
+  def options_sym(options)
+    options.map do |option|
+      {
+        'id' => option.id,
+        'name' => option.name,
+        'correct' => option.correct
+      }.transform_keys(&:to_sym)
+    end
+  end
+
+  def options_hash(options)
+    options.map do |option|
+      {
+        'id' => option.id,
+        'name' => option.name,
+        'correct' => option.correct
+      }
+    end
+  end
+
+  def answers_survey_questions_attributes_sym(survey_question, question_type, options)
+    {
+      'id' => survey_question.id,
+      'name' => survey_question.name,
+      'question_type' => question_type(question_type).transform_keys(&:to_sym),
+      'options' => options_sym(options)
+    }.transform_keys(&:to_sym)
+  end
+
+  def answers_survey_questions_attributes_hash(survey_question, question_type, options)
+    {
+      'id' => survey_question.id,
+      'name' => survey_question.name,
+      'question_type' => question_type(question_type),
+      'options' => options_hash(options)
+    }
+  end
+
+  def asnwers_survey_returned_params(params = {})
+    answers_survey = params[:answers_survey]
+
+    {
+      'id' => answers_survey.id,
+      'user_id' => answers_survey.user_id,
+      'status' => answers_survey.status,
+      'questions' => params[:question_attributes],
+      'answered_questions' => [params[:answered_question_attributes]],
+      'not_answered_questions' => [params[:unanswered_question_attributes]],
+      'current_question_index' => 1
+    }
+  end
+
+  def survey_helper
+    {
+      id: survey.id,
+      name: survey.name,
+      description: survey.description,
+      survey_subject_id: survey.survey_subject.id,
+      answered_questions_quantity: 1,
+      total_questions_quantity: 2
+    }
+  end
+end


### PR DESCRIPTION
The HashHelper was igrnored by rubocop and reek.
In order to fix this HahsHelper was refactored.

fix #502

# Refactor HashHelper

- In order to avoid `rubocop error:` `max length of module 100 lines` :
  -  for duplicated code I created private methods in `HashHelperMethod.rb` that are accessible from `HashHelper.rb` file. 

#### Only select the appropriate.

- [ ] **Model testing.**
- [ ] **Request testing and swagger doc update.**
- [ ] **System testing.**
- [ ] **No tests required.**
