### PR TITLE
feat: add status tag to survey card

### DIFF
--- a/frontend/src/components/main/SurveysList.tsx
+++ b/frontend/src/components/main/SurveysList.tsx
@@ -73,6 +73,7 @@ export const SurveysList = (props: SurveyListProps) => {
           onClick={() => registerAnswerSurvey(item.id, item)}
           loading={loading && selectedSurvey === item.id}
           surveyData={item}
+          status={item.current_answers_survey?.status}
         />
       ))}
     </Grid>

--- a/frontend/src/components/survey-item/survey-item.style.tsx
+++ b/frontend/src/components/survey-item/survey-item.style.tsx
@@ -4,6 +4,8 @@ export const SurveyContainer = styled.div`
   border-radius: 6px;
   cursor: pointer;
   margin: 10px;
+  display: flex;
+  flex-direction: column;
 `;
 
 export const ImageSurvey = styled.div<{ cover: string }>`
@@ -25,6 +27,10 @@ export const DetailsSurvey = styled.div`
   background-color: #fff;
   border-bottom-left-radius: 6px;
   border-bottom-right-radius: 6px;
+  flex-grow: 1;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
 `;
 
 export const TitleSurvey = styled.div`

--- a/frontend/src/components/survey-item/survey-item.test.tsx
+++ b/frontend/src/components/survey-item/survey-item.test.tsx
@@ -74,16 +74,40 @@ describe('SurveyItem', () => {
     expect(rendered.getByText('No questions')).toBeTruthy();
   });
 
-  it('should show current status of survey', () => {
-    const rendered = render(
-      <SurveyItem
-        title="Survey name"
-        description="Available your instincts now"
-        numberQuestions={1}
-        status={AnswerSurveyStatus.Completed}
-      />
-    );
-    expect(rendered.getByText('Completed')).toBeTruthy();
+  describe('should show current status of survey', () => {
+    it('should show completed tag when survey is completed', () => {
+      const rendered = render(
+        <SurveyItem
+          title="Survey name"
+          description="Available your instincts now"
+          numberQuestions={1}
+          status={AnswerSurveyStatus.Completed}
+        />
+      );
+      expect(rendered.getByText(AnswerSurveyStatus.Completed)).toBeTruthy();
+    });
+    it('should show started tag when survey is started', () => {
+      const rendered = render(
+        <SurveyItem
+          title="Survey name"
+          description="Available your instincts now"
+          numberQuestions={1}
+          status={AnswerSurveyStatus.Started}
+        />
+      );
+      expect(rendered.getByText(AnswerSurveyStatus.Started)).toBeTruthy();
+    });
+    it('should show not started tag when survey is not started', () => {
+      const rendered = render(
+        <SurveyItem
+          title="Survey name"
+          description="Available your instincts now"
+          numberQuestions={1}
+          status={AnswerSurveyStatus.NotStarted}
+        />
+      );
+      expect(rendered.getByText(AnswerSurveyStatus.NotStarted)).toBeTruthy();
+    });
   });
 
   it('should show resume button when started survey', () => {

--- a/frontend/src/components/survey-item/survey-item.test.tsx
+++ b/frontend/src/components/survey-item/survey-item.test.tsx
@@ -74,12 +74,24 @@ describe('SurveyItem', () => {
     expect(rendered.getByText('No questions')).toBeTruthy();
   });
 
+  it('should show current status of survey', () => {
+    const rendered = render(
+      <SurveyItem
+        title="Survey name"
+        description="Available your instincts now"
+        numberQuestions={1}
+        status={AnswerSurveyStatus.Completed}
+      />
+    );
+    expect(rendered.getByText('Completed')).toBeTruthy();
+  });
+
   it('should show resume button when started survey', () => {
     const rendered = render(<SurveyItem {...startedSurvey} />);
     expect(rendered.getByText('Click to resume')).toBeTruthy();
   });
 
-  it('not should show resume button when started survey', () => {
+  it('should not show resume button when started survey', () => {
     const notStartedSurvey = startedSurvey;
     notStartedSurvey.surveyData.answers_surveys = [];
 

--- a/frontend/src/components/survey-item/survey-item.tsx
+++ b/frontend/src/components/survey-item/survey-item.tsx
@@ -1,7 +1,8 @@
 import { RiQuestionAnswerLine } from 'react-icons/ri';
 import { MouseEventHandler, useEffect, useState } from 'react';
 import { Progress } from '@chakra-ui/progress';
-import { Survey } from '@api/models/survey';
+import { Tag } from '@chakra-ui/tag';
+import { Survey, AnswerSurveyStatus } from '@api/models/survey';
 import {
   DescriptionSurvey,
   DetailsSurvey,
@@ -21,6 +22,7 @@ export interface SurveyItemProps {
   onClick?: MouseEventHandler<HTMLDivElement>;
   loading?: boolean;
   surveyData?: Survey;
+  status?: AnswerSurveyStatus;
 }
 
 export const SurveyItem = (props: SurveyItemProps) => {
@@ -32,6 +34,7 @@ export const SurveyItem = (props: SurveyItemProps) => {
     onClick,
     loading,
     surveyData,
+    status,
   } = props;
   const [coverImage, setCoverImage] = useState<string>('');
 
@@ -48,6 +51,19 @@ export const SurveyItem = (props: SurveyItemProps) => {
         '&cs=tinysrgb&dpr=2&h=650&w=940',
     ];
     return images[Math.floor(Math.random() * images.length)];
+  };
+
+  const getStatusColor = () => {
+    switch (status) {
+      case AnswerSurveyStatus.Completed:
+        return 'green';
+      case AnswerSurveyStatus.Started:
+        return 'yellow';
+      case AnswerSurveyStatus.NotStarted:
+        return 'red';
+      default:
+        return 'gray';
+    }
   };
 
   useEffect(() => {
@@ -68,14 +84,13 @@ export const SurveyItem = (props: SurveyItemProps) => {
           <span>
             {surveyData?.answers_surveys.length ? 'Click to resume' : ''}
           </span>
+          <Tag size="sm" colorScheme={getStatusColor()}>
+            {status}
+          </Tag>
           <QuestionsSection>
             <RiQuestionAnswerLine size={20} />
             {numberQuestions > 0 ? (
-              <NumberQuestions>
-                {numberQuestions}
-                {' '}
-                Questions
-              </NumberQuestions>
+              <NumberQuestions>{numberQuestions} Questions</NumberQuestions>
             ) : (
               <NumberQuestions>No questions</NumberQuestions>
             )}

--- a/frontend/src/components/survey-item/survey-item.tsx
+++ b/frontend/src/components/survey-item/survey-item.tsx
@@ -25,6 +25,12 @@ export interface SurveyItemProps {
   status?: AnswerSurveyStatus;
 }
 
+const StatusTagColors = {
+  [AnswerSurveyStatus.NotStarted]: 'red',
+  [AnswerSurveyStatus.Started]: 'yellow',
+  [AnswerSurveyStatus.Completed]: 'green',
+};
+
 export const SurveyItem = (props: SurveyItemProps) => {
   const {
     title,
@@ -53,19 +59,6 @@ export const SurveyItem = (props: SurveyItemProps) => {
     return images[Math.floor(Math.random() * images.length)];
   };
 
-  const getStatusColor = () => {
-    switch (status) {
-      case AnswerSurveyStatus.Completed:
-        return 'green';
-      case AnswerSurveyStatus.Started:
-        return 'yellow';
-      case AnswerSurveyStatus.NotStarted:
-        return 'red';
-      default:
-        return 'gray';
-    }
-  };
-
   useEffect(() => {
     setCoverImage(cover || randomImage());
   }, []);
@@ -84,7 +77,7 @@ export const SurveyItem = (props: SurveyItemProps) => {
           <span>
             {surveyData?.answers_surveys.length ? 'Click to resume' : ''}
           </span>
-          <Tag size="sm" colorScheme={getStatusColor()}>
+          <Tag size="sm" colorScheme={StatusTagColors[status]}>
             {status}
           </Tag>
           <QuestionsSection>


### PR DESCRIPTION
fix #535 #536 
## Add status tag to survey card and fix heigth when survey don't have a description
####
New tag example:
![image](https://user-images.githubusercontent.com/57760325/150642956-eccdc550-c75c-40d5-adcb-2fcf45e35e5b.png)
####
- [ ] **Model testing.**
- [ ] **Request testing and swagger doc update.**
- [x] **System testing.**
- [ ] **No tests required.**
