### PR TITLE
🔨 Fix: empty status tag

### DIFF
--- a/frontend/src/components/main/SurveysList.tsx
+++ b/frontend/src/components/main/SurveysList.tsx
@@ -73,7 +73,9 @@ export const SurveysList = (props: SurveyListProps) => {
           onClick={() => registerAnswerSurvey(item.id, item)}
           loading={loading && selectedSurvey === item.id}
           surveyData={item}
-          status={item.current_answers_survey?.status}
+          status={
+            item.current_answers_survey?.status || AnswerSurveyStatus.NotStarted
+          }
         />
       ))}
     </Grid>

--- a/frontend/src/components/survey-item/survey-item.tsx
+++ b/frontend/src/components/survey-item/survey-item.tsx
@@ -74,9 +74,9 @@ export const SurveyItem = (props: SurveyItemProps) => {
           <span>{description}</span>
         </DescriptionSurvey>
         <QuestionsSurvey>
-          <span>
-            {surveyData?.answers_surveys.length ? 'Click to resume' : ''}
-          </span>
+          {surveyData?.answers_surveys.length > 0 && (
+            <span>Click to resume</span>
+          )}
           <Tag size="sm" colorScheme={StatusTagColors[status]}>
             {status}
           </Tag>


### PR DESCRIPTION
related to #536 

## Fix survey status tag
Fix status tag when current surveys answers is empty to show 'Not started' and tag position.

