### PR TITLE
Display type of questions in a Survey

### DIFF
--- a/backend/app/controllers/surveys_controller.rb
+++ b/backend/app/controllers/surveys_controller.rb
@@ -6,7 +6,7 @@ class SurveysController < ApplicationController
   private
 
   def survey_presenters
-    Survey.ready_surveys.includes(questions: %i[question_type]).decorate.map do |survey|
+    Survey.ready_surveys.includes(questions: %i[question_type options]).decorate.map do |survey|
       SurveyPresenter.payload(survey, current_user)
     end
   end

--- a/backend/app/helpers/survey_helper.rb
+++ b/backend/app/helpers/survey_helper.rb
@@ -1,0 +1,16 @@
+module SurveyHelper
+  def question_type_translation_key(array)
+    array.map do |type|
+      t("surveys.index.question_type.#{type.downcase.split.join('_')}")
+    end
+  end
+
+  def question_types(survey)
+    array_of_question_types = []
+    survey[:questions].each do |question|
+      array_of_question_types << question[:question_type][:name]
+    end
+
+    question_type_translation_key(array_of_question_types.uniq.sort!)
+  end
+end

--- a/backend/app/views/surveys/index.slim
+++ b/backend/app/views/surveys/index.slim
@@ -9,8 +9,13 @@
             p.card-text
               = survey[:description]
             p.card-text
+              =  question_types(survey).join(", ")
+              =< t('surveys.index.type_of_questions')
+              | .
+            p.card-text
               =  t('surveys.index.question', count: survey[:answered_questions_quantity])
-              |  answered.
+              =< t('surveys.index.answered')
+              | .
             = form_with url: answers_surveys_path, method: :post do |form|
               = form.hidden_field :survey_id, value: survey[:id]
               = form.submit t('surveys.answers.submit'), class: 'btn btn-primary'

--- a/backend/config/locales/en.yml
+++ b/backend/config/locales/en.yml
@@ -69,6 +69,12 @@ en:
     answers:
       submit: Answer
     index:
+      answered: answered
       question:
         one: "%{count} question"
         other: "%{count} questions"
+      question_type:
+        free_text: Free text
+        multiple_choice: Multiple choice
+        single_choice: Single choice
+      type_of_questions: type of questions

--- a/backend/config/locales/pt-br.yml
+++ b/backend/config/locales/pt-br.yml
@@ -69,6 +69,12 @@ pt-br:
     answers:
       submit: Responder
     index:
+      answered: respondida
       question:
         one: "%{count} questão"
         other: "%{count} questões"
+      question_type:
+        free_text: Texto livre
+        multiple_choice: Múltipla escolha
+        single_choice: Escolha única
+      type_of_questions: tipo de perguntas

--- a/backend/spec/factories/questions.rb
+++ b/backend/spec/factories/questions.rb
@@ -21,7 +21,23 @@ FactoryBot.define do
     options { create_list :correct_option, 1 }
   end
 
+  factory :single_choice_ready_question, parent: :single_choice_question do
+    after(:create) do |question|
+      create(:correct_option, question: question)
+      question.ready_to_be_answered = true
+      question.save!
+    end
+  end
+
   factory :multiple_choice_ready_question, parent: :multiple_choice_question do
+    after(:create) do |question|
+      create(:correct_option, question: question)
+      question.ready_to_be_answered = true
+      question.save!
+    end
+  end
+
+  factory :free_text_ready_question, parent: :free_text_question do
     after(:create) do |question|
       create(:correct_option, question: question)
       question.ready_to_be_answered = true

--- a/backend/spec/factories/surveys.rb
+++ b/backend/spec/factories/surveys.rb
@@ -46,6 +46,33 @@ FactoryBot.define do
     end
   end
 
+  factory :ready_survey_with_diff_type_of_questions, parent: :survey do
+    after(:create) do |survey|
+      survey.questions = [
+        create(:single_choice_ready_question, user: survey.user, survey: survey),
+        create(:multiple_choice_ready_question, user: survey.user, survey: survey)
+      ]
+      survey.ready = true
+      survey.save!
+    end
+  end
+
+  factory :ready_survey_single_choise_question, parent: :survey do
+    after(:create) do |survey|
+      survey.questions = create_list(:single_choice_ready_question, 1, user: survey.user, survey: survey)
+      survey.ready = true
+      survey.save!
+    end
+  end
+
+  factory :ready_survey_free_text_question, parent: :survey do
+    after(:create) do |survey|
+      survey.questions = create_list(:free_text_ready_question, 1, user: survey.user, survey: survey)
+      survey.ready = true
+      survey.save!
+    end
+  end
+
   factory :survey_with_answer, parent: :ready_survey do
     after(:create) do |survey|
       answersurvey = create(:answers_survey_with_some_answers, survey: survey, user: survey.user)

--- a/backend/spec/system/front_end/survey_crud_spec.rb
+++ b/backend/spec/system/front_end/survey_crud_spec.rb
@@ -25,6 +25,47 @@ RSpec.describe 'Survey CRUD', type: :system do
 
         it { expect(page).to have_text('2 questions answered') }
       end
+
+      context 'with single questions' do
+        let(:survey) { create(:ready_survey_single_choise_question, user: user_student) }
+
+        before do
+          create(:single_choice_ready_question, user: user_student)
+          visit surveys_path
+        end
+
+        it { expect(page).to have_text('Single choice type of questions.') }
+      end
+
+      context 'with multiple questions' do
+        before do
+          create(:multiple_choice_ready_question, user: user_student)
+          visit surveys_path
+        end
+
+        it { expect(page).to have_text('Multiple choice type of questions.') }
+      end
+
+      context 'with free text questions' do
+        let(:survey) { create(:ready_survey_free_text_question, user: user_student) }
+
+        before do
+          create(:free_text_ready_question, user: user_student)
+          visit surveys_path
+        end
+
+        it { expect(page).to have_text('Free text type of questions.') }
+      end
+
+      context 'with multiple choise and free text questions' do
+        let(:survey) { create(:ready_survey_with_diff_type_of_questions, user: user_student) }
+
+        before do
+          visit surveys_path
+        end
+
+        it { expect(page).to have_text('Multiple choice, Single choice type of questions.') }
+      end
     end
   end
 end


### PR DESCRIPTION
fix #497 

# Show survey question-types at index-page

Add `survey_helper.rb` with methods:
- `question_types` to create an array with the question types for a certain  survey.
- `question_type_translation_key` to help the question types to be translated.

#### Only select the appropriate.

- [ ] **Model testing.**
- [ ] **Request testing and swagger doc update.**
- [x] **System testing.**
- [ ] **No tests required.**
