### PR TITLE
Add schema comment to models

### DIFF
--- a/backend/Gemfile
+++ b/backend/Gemfile
@@ -55,6 +55,9 @@ group :development do
 
   # Spring speeds up development by keeping your application running in the background. Read more: https://github.com/rails/spring
   gem 'spring'
+
+  #Add a comment summarizing the current schema. Read more : https://github.com/ctran/annotate_models
+  gem 'annotate'
 end
 
 gem 'administrate'

--- a/backend/Gemfile.lock
+++ b/backend/Gemfile.lock
@@ -95,6 +95,9 @@ GEM
       momentjs-rails (~> 2.8)
       sassc-rails (~> 2.1)
       selectize-rails (~> 0.6)
+    annotate (3.2.0)
+      activerecord (>= 3.2, < 8.0)
+      rake (>= 10.4, < 14.0)
     ast (2.4.2)
     autoprefixer-rails (10.4.2.0)
       execjs (~> 2)
@@ -500,6 +503,7 @@ PLATFORMS
 DEPENDENCIES
   active_model_serializers
   administrate
+  annotate
   bootsnap (>= 1.4.4)
   bootstrap (~> 5.0.0.beta1)
   brakeman

--- a/backend/app/models/answer.rb
+++ b/backend/app/models/answer.rb
@@ -1,3 +1,14 @@
+# == Schema Information
+#
+# Table name: answers
+#
+#  id                :bigint           not null, primary key
+#  user_answer       :string
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  answers_survey_id :bigint           not null
+#  question_id       :bigint           not null
+#
 class Answer < ApplicationRecord
   belongs_to :question
   belongs_to :answers_survey

--- a/backend/app/models/answers_option.rb
+++ b/backend/app/models/answers_option.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: answers_options
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  answer_id  :bigint           not null
+#  option_id  :bigint           not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (answer_id => answers.id)
+#  fk_rails_...  (option_id => options.id)
+#
 class AnswersOption < ApplicationRecord
   belongs_to :answer
   belongs_to :option

--- a/backend/app/models/answers_survey.rb
+++ b/backend/app/models/answers_survey.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: answers_surveys
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  survey_id  :bigint           not null
+#  user_id    :bigint           not null
+#
 class AnswersSurvey < ApplicationRecord
   belongs_to :user
   belongs_to :survey

--- a/backend/app/models/group.rb
+++ b/backend/app/models/group.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: groups
+#
+#  id                  :bigint           not null, primary key
+#  description         :string
+#  name                :string           not null
+#  created_at          :datetime         not null
+#  updated_at          :datetime         not null
+#  group_dependency_id :integer
+#  trail_id            :integer
+#  user_id             :bigint           not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 # :reek:MissingSafeMethod { exclude: [ add_required_group! ] }
 class Group < ApplicationRecord
   belongs_to :user

--- a/backend/app/models/group_dependency.rb
+++ b/backend/app/models/group_dependency.rb
@@ -1,3 +1,16 @@
+# == Schema Information
+#
+# Table name: group_dependencies
+#
+#  id         :bigint           not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  group_id   :bigint           not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (group_id => groups.id)
+#
 class GroupDependency < ApplicationRecord
   belongs_to :group
   has_many :groups, dependent: :nullify

--- a/backend/app/models/option.rb
+++ b/backend/app/models/option.rb
@@ -1,3 +1,20 @@
+# == Schema Information
+#
+# Table name: options
+#
+#  id          :bigint           not null, primary key
+#  correct     :boolean          default(FALSE)
+#  name        :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  question_id :bigint           not null
+#  user_id     :bigint           not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (question_id => questions.id)
+#  fk_rails_...  (user_id => users.id)
+#
 class Option < ApplicationRecord
   belongs_to :user
   belongs_to :question

--- a/backend/app/models/question.rb
+++ b/backend/app/models/question.rb
@@ -1,3 +1,17 @@
+# == Schema Information
+#
+# Table name: questions
+#
+#  id                   :bigint           not null, primary key
+#  image_url            :string
+#  name                 :string
+#  ready_to_be_answered :boolean          default(FALSE)
+#  created_at           :datetime         not null
+#  updated_at           :datetime         not null
+#  question_type_id     :integer          not null
+#  survey_id            :integer
+#  user_id              :integer          not null
+#
 class Question < ApplicationRecord
   validates :image_url, format: { with: /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/ }, allow_blank: true
   validates :name, presence: true, uniqueness: { scope: :user_id }

--- a/backend/app/models/question_type.rb
+++ b/backend/app/models/question_type.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: question_types
+#
+#  id         :bigint           not null, primary key
+#  name       :string           not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class QuestionType < ApplicationRecord
   validates :name, presence: true
   validates :name, uniqueness: { case_sensitive: false }

--- a/backend/app/models/role.rb
+++ b/backend/app/models/role.rb
@@ -1,3 +1,12 @@
+# == Schema Information
+#
+# Table name: roles
+#
+#  id         :bigint           not null, primary key
+#  role_type  :string
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
 class Role < ApplicationRecord
   has_many :users, dependent: :nullify
   validates :role_type, presence: true

--- a/backend/app/models/survey.rb
+++ b/backend/app/models/survey.rb
@@ -1,3 +1,23 @@
+# == Schema Information
+#
+# Table name: surveys
+#
+#  id                :bigint           not null, primary key
+#  description       :string
+#  icon_url          :string
+#  image_url         :string
+#  name              :string
+#  ready             :boolean          default(FALSE)
+#  created_at        :datetime         not null
+#  updated_at        :datetime         not null
+#  group_id          :integer
+#  survey_subject_id :bigint           not null
+#  user_id           :bigint           not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (survey_subject_id => survey_subjects.id)
+#
 class Survey < ApplicationRecord
   validate :validates_ready
   validates :icon_url, :image_url, format: { with: /\A#{URI::DEFAULT_PARSER.make_regexp(%w[http https])}\z/ }, allow_blank: true

--- a/backend/app/models/survey_subject.rb
+++ b/backend/app/models/survey_subject.rb
@@ -1,3 +1,13 @@
+# == Schema Information
+#
+# Table name: survey_subjects
+#
+#  id          :bigint           not null, primary key
+#  description :string
+#  name        :string
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#
 class SurveySubject < ApplicationRecord
   has_many :surveys, dependent: :destroy
 

--- a/backend/app/models/trail.rb
+++ b/backend/app/models/trail.rb
@@ -1,3 +1,18 @@
+# == Schema Information
+#
+# Table name: trails
+#
+#  id          :bigint           not null, primary key
+#  description :string
+#  name        :string           not null
+#  created_at  :datetime         not null
+#  updated_at  :datetime         not null
+#  user_id     :bigint           not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
+#
 class Trail < ApplicationRecord
   has_many :groups, dependent: :nullify
   belongs_to :user, dependent: :destroy

--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,3 +1,22 @@
+# == Schema Information
+#
+# Table name: users
+#
+#  id                     :bigint           not null, primary key
+#  email                  :string           default(""), not null
+#  encrypted_password     :string           default(""), not null
+#  phone                  :string
+#  remember_created_at    :datetime
+#  reset_password_sent_at :datetime
+#  reset_password_token   :string
+#  created_at             :datetime         not null
+#  updated_at             :datetime         not null
+#  role_id                :bigint           not null
+#
+# Foreign Keys
+#
+#  fk_rails_...  (role_id => roles.id)
+#
 class User < ApplicationRecord
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable

--- a/backend/lib/tasks/auto_annotate_models.rake
+++ b/backend/lib/tasks/auto_annotate_models.rake
@@ -1,0 +1,59 @@
+# NOTE: only doing this in development as some production environments (Heroku)
+# NOTE: are sensitive to local FS writes, and besides -- it's just not proper
+# NOTE: to have a dev-mode tool do its thing in production.
+if Rails.env.development?
+  require 'annotate'
+  task :set_annotation_options do
+    # You can override any of these by setting an environment variable of the
+    # same name.
+    Annotate.set_defaults(
+      'active_admin'                => 'false',
+      'additional_file_patterns'    => [],
+      'routes'                      => 'false',
+      'models'                      => 'true',
+      'position_in_routes'          => 'before',
+      'position_in_class'           => 'before',
+      'position_in_test'            => 'before',
+      'position_in_fixture'         => 'before',
+      'position_in_factory'         => 'before',
+      'position_in_serializer'      => 'before',
+      'show_foreign_keys'           => 'true',
+      'show_complete_foreign_keys'  => 'false',
+      'show_indexes'                => 'false',
+      'simple_indexes'              => 'false',
+      'model_dir'                   => 'app/models',
+      'root_dir'                    => '',
+      'include_version'             => 'false',
+      'require'                     => '',
+      'exclude_tests'               => 'true',
+      'exclude_fixtures'            => 'false',
+      'exclude_factories'           => 'true',
+      'exclude_serializers'         => 'true',
+      'exclude_scaffolds'           => 'true',
+      'exclude_controllers'         => 'true',
+      'exclude_helpers'             => 'true',
+      'exclude_sti_subclasses'      => 'false',
+      'ignore_model_sub_dir'        => 'false',
+      'ignore_columns'              => nil,
+      'ignore_routes'               => nil,
+      'ignore_unknown_models'       => 'false',
+      'hide_limit_column_types'     => 'integer,bigint,boolean',
+      'hide_default_column_types'   => 'json,jsonb,hstore',
+      'skip_on_db_migrate'          => 'false',
+      'format_bare'                 => 'true',
+      'format_rdoc'                 => 'false',
+      'format_yard'                 => 'false',
+      'format_markdown'             => 'false',
+      'sort'                        => 'false',
+      'force'                       => 'false',
+      'frozen'                      => 'false',
+      'classified_sort'             => 'true',
+      'trace'                       => 'false',
+      'wrapper_open'                => nil,
+      'wrapper_close'               => nil,
+      'with_comment'                => 'true'
+    )
+  end
+
+  Annotate.load_tasks
+end


### PR DESCRIPTION
fix #710 

The schema comment was added to the models files showing the current schema. The annotate gem also can add comment to:
- ActiveRecord models
- Fixture files
- Tests and Specs
- Object Daddy exemplars
- Machinist blueprints
- Fabrication fabricators
- Thoughtbot's factory_bot factories
- routes.rb file (for Rails projects)

So if someone think it's better to add in some other file, please let me know.
